### PR TITLE
Added ability to add/remove typename and member names from type hash

### DIFF
--- a/gen/ZCMGen.cpp
+++ b/gen/ZCMGen.cpp
@@ -152,13 +152,17 @@ i64 ZCMStruct::computeHash()
     // this allows people to rename data types and still have them work.
     //
     // In contrast, we DO hash the types of a structs members (and their names).
-#ifdef ENABLE_TYPENAME_HASHING
+
+    #ifdef ENABLE_TYPENAME_HASHING
     v = hashUpdate(v, structname);
-#endif
+    #endif
 
     for (auto& m : members) {
+
+        #ifdef ENABLE_MEMBERNAME_HASHING
         // hash the member name
         v = hashUpdate(v, m.membername);
+        #endif
 
         // if the member is a primitive type, include the type
         // signature in the hash. Do not include them for compound

--- a/gen/ZCMGen.cpp
+++ b/gen/ZCMGen.cpp
@@ -154,7 +154,7 @@ i64 ZCMStruct::computeHash()
     // In contrast, we DO hash the types of a structs members (and their names).
 
     #ifdef ENABLE_TYPENAME_HASHING
-    v = hashUpdate(v, structname);
+    v = hashUpdate(v, structname.shortname);
     #endif
 
     for (auto& m : members) {

--- a/tools/cpp/spy-lite/main.cpp
+++ b/tools/cpp/spy-lite/main.cpp
@@ -41,7 +41,7 @@ struct SpyInfo
 
     bool isValidChannelnum(size_t index)
     {
-        return (0 <= index && index < names.size());
+        return index < names.size();
     }
 
     void addMessage(const char *channel, const zcm_recv_buf_t *rbuf)

--- a/wscript
+++ b/wscript
@@ -34,6 +34,13 @@ def add_zcm_configure_options(ctx):
     add_use_option('zmq',     'Enable ZeroMQ features')
     add_use_option('cxxtest', 'Enable build of cxxtests')
 
+    gr.add_option('--hash-members',  dest='hash_members', default=False,
+                  type='choice', choices=['true', 'false'],
+                  action='store', help='Include the zcmtype members names in the hash generation')
+    gr.add_option('--hash-typename', dest='hash_typename', default=True,
+                  type='choice', choices=['true', 'false'],
+                  action='store', help='Include the zcmtype name in the hash generation')
+
     add_trans_option('inproc', 'Enable the In-Process transport (Requires ZeroMQ)')
     add_trans_option('ipc',    'Enable the IPC transport (Requires ZeroMQ)')
     add_trans_option('udpm',   'Enable the UDP Multicast transport (LCM-compatible)')
@@ -74,6 +81,9 @@ def process_zcm_configure_options(ctx):
     env.USING_TRANS_UDPM   = hasopt('use_udpm')
     env.USING_TRANS_SERIAL = hasopt('use_serial')
 
+    env.HASH_TYPENAME = getattr(opt, 'hash_typename')
+    env.HASH_MEMBERS = getattr(opt, 'hash_members')
+
     ZMQ_REQUIRED = env.USING_TRANS_IPC or env.USING_TRANS_INPROC
     if ZMQ_REQUIRED and not env.USING_ZMQ:
         raise WafError("Using ZeroMQ is required for some of the selected transports (--use-zmq)")
@@ -97,6 +107,10 @@ def process_zcm_configure_options(ctx):
     print_entry("inproc", env.USING_TRANS_INPROC)
     print_entry("udpm",   env.USING_TRANS_UDPM)
     print_entry("serial", env.USING_TRANS_SERIAL)
+
+    Logs.pprint('BLUE', '\nType Configuration:')
+    print_entry("hash-typename", env.HASH_TYPENAME)
+    print_entry("hash-members",  env.HASH_MEMBERS)
 
     Logs.pprint('NORMAL', '')
 
@@ -143,6 +157,11 @@ def setup_environment(ctx):
         if k.startswith('USING_'):
             if getattr(ctx.env, k):
                 ctx.env.DEFINES_default.append(k)
+
+    if ctx.env.HASH_TYPENAME:
+        ctx.env.DEFINES_default.append("ENABLE_TYPENAME_HASHING")
+    if ctx.env.HASH_MEMBERS:
+        ctx.env.DEFINES_default.append("ENABLE_MEMBERNAME_HASHING")
 
     if ctx.env.USING_OPT:
         ctx.env.CFLAGS_default   += OPT_FLAGS

--- a/wscript
+++ b/wscript
@@ -34,10 +34,10 @@ def add_zcm_configure_options(ctx):
     add_use_option('zmq',     'Enable ZeroMQ features')
     add_use_option('cxxtest', 'Enable build of cxxtests')
 
-    gr.add_option('--hash-member-names',  dest='hash_members', default=False,
+    gr.add_option('--hash-member-names',  dest='hash_member_names', default='false',
                   type='choice', choices=['true', 'false'],
                   action='store', help='Include the zcmtype members names in the hash generation')
-    gr.add_option('--hash-typename', dest='hash_typename', default=True,
+    gr.add_option('--hash-typename', dest='hash_typename', default='true',
                   type='choice', choices=['true', 'false'],
                   action='store', help='Include the zcmtype name in the hash generation')
 
@@ -82,14 +82,14 @@ def process_zcm_configure_options(ctx):
     env.USING_TRANS_SERIAL = hasopt('use_serial')
 
     env.HASH_TYPENAME = getattr(opt, 'hash_typename')
-    env.HASH_MEMBERS = getattr(opt, 'hash_members')
+    env.HASH_MEMBER_NAMES = getattr(opt, 'hash_member_names')
 
     ZMQ_REQUIRED = env.USING_TRANS_IPC or env.USING_TRANS_INPROC
     if ZMQ_REQUIRED and not env.USING_ZMQ:
         raise WafError("Using ZeroMQ is required for some of the selected transports (--use-zmq)")
 
     def print_entry(name, enabled):
-        Logs.pprint("NORMAL", "    {:15}".format(name), sep='')
+        Logs.pprint("NORMAL", "    {:20}".format(name), sep='')
         if enabled:
             Logs.pprint("GREEN", "Enabled")
         else:
@@ -109,8 +109,8 @@ def process_zcm_configure_options(ctx):
     print_entry("serial", env.USING_TRANS_SERIAL)
 
     Logs.pprint('BLUE', '\nType Configuration:')
-    print_entry("hash-typename", env.HASH_TYPENAME)
-    print_entry("hash-members",  env.HASH_MEMBERS)
+    print_entry("hash-typename", env.HASH_TYPENAME == 'true')
+    print_entry("hash-member-names",  env.HASH_MEMBER_NAMES == 'true')
 
     Logs.pprint('NORMAL', '')
 
@@ -158,9 +158,9 @@ def setup_environment(ctx):
             if getattr(ctx.env, k):
                 ctx.env.DEFINES_default.append(k)
 
-    if ctx.env.HASH_TYPENAME:
+    if ctx.env.HASH_TYPENAME == 'true':
         ctx.env.DEFINES_default.append("ENABLE_TYPENAME_HASHING")
-    if ctx.env.HASH_MEMBERS:
+    if ctx.env.HASH_MEMBER_NAMES == 'true':
         ctx.env.DEFINES_default.append("ENABLE_MEMBERNAME_HASHING")
 
     if ctx.env.USING_OPT:

--- a/wscript
+++ b/wscript
@@ -34,7 +34,7 @@ def add_zcm_configure_options(ctx):
     add_use_option('zmq',     'Enable ZeroMQ features')
     add_use_option('cxxtest', 'Enable build of cxxtests')
 
-    gr.add_option('--hash-members',  dest='hash_members', default=False,
+    gr.add_option('--hash-member-names',  dest='hash_members', default=False,
                   type='choice', choices=['true', 'false'],
                   action='store', help='Include the zcmtype members names in the hash generation')
     gr.add_option('--hash-typename', dest='hash_typename', default=True,

--- a/zcm/blocking.cpp
+++ b/zcm/blocking.cpp
@@ -77,11 +77,12 @@ static bool isRegexChannel(const string& channel)
     return false;
 }
 
-class zcm_blocking
+struct zcm_blocking
 {
+  private:
     using SubList = vector<zcm_sub_t*>;
 
-public:
+  public:
     zcm_blocking(zcm_t *z, zcm_trans_t *zt_);
     ~zcm_blocking();
 

--- a/zcm/zcm-cpp.hpp
+++ b/zcm/zcm-cpp.hpp
@@ -15,8 +15,9 @@ class Subscription;
 
 // TODO: unify pointer style pref "Msg* msg" vs "Msg *msg", I'd tend toward the former
 
-struct ZCM
+class ZCM
 {
+  public:
     // TODO: update to match new url based zcm_create
     inline ZCM();
     inline ZCM(const std::string& transport);


### PR DESCRIPTION
Will send an email to zcm-users mailing list once this gets merged in. Will notify everyone that this change will break receiving messages from old logs unless you set up the hash correctly. The replicate old behavior, you should use --hash-typename=false and --hash-members=true