### PR TITLE
Api transports recv utime

### DIFF
--- a/examples/cpp/transport/SerialTransportTest.cpp
+++ b/examples/cpp/transport/SerialTransportTest.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <queue>
 #include <sys/time.h>
+#include <cassert>
 
 #include "zcm/zcm-cpp.hpp"
 
@@ -10,7 +11,7 @@
 using namespace std;
 using namespace zcm;
 
-#define PUBLISH_DT (1e6)/(500)
+#define PUBLISH_DT (1e6)/(5)
 #define BUFFER_SIZE 200
 #define MIN(A, B) ((A) < (B)) ? (A) : (B)
 
@@ -59,11 +60,10 @@ class Handler
   public:
     void handle(const ReceiveBuffer* rbuf, const string& chan, const example_t* msg)
     {
-        cout << "Got one" << endl;
+        cout << "Message received" << endl;
 
-        if (msg->timestamp <= lastHost)  {
-            cout << "ERROR" << endl;
-            while(1);
+        if (msg->timestamp <= lastHost || rbuf->recv_utime < lastHost)  {
+            assert("ERROR: utime mismatch. This should never happen");
         }
         lastHost = msg->timestamp;
 

--- a/examples/cpp/transport/SerialTransportTest.cpp
+++ b/examples/cpp/transport/SerialTransportTest.cpp
@@ -45,7 +45,7 @@ static uint32_t put(const uint8_t* data, uint32_t nData, void* usr)
     return n;
 }
 
-static uint64_t utime()
+static uint64_t utime(void* usr)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -72,7 +72,7 @@ class Handler
 
 int main(int argc, const char *argv[])
 {
-    ZCM zcmLocal(zcm_trans_generic_serial_create(&get, &put, NULL));
+    ZCM zcmLocal(zcm_trans_generic_serial_create(&get, &put, &utime, NULL));
 
     example_t example;
     example.num_ranges = 1;
@@ -82,13 +82,13 @@ int main(int argc, const char *argv[])
     Handler handler;
     auto sub = zcmLocal.subscribe("EXAMPLE", &Handler::handle, &handler);
 
-    uint64_t nextPublish = utime();
+    uint64_t nextPublish = 0;
     while (true)
     {
-        uint64_t now = utime();
+        uint64_t now = utime(NULL);
         if (now > nextPublish) {
             cout << "Publishing" << endl;
-            example.timestamp = utime();
+            example.timestamp = now;
             zcmLocal.publish("EXAMPLE", &example);
             nextPublish = now + PUBLISH_DT;
         }

--- a/zcm/blocking.cpp
+++ b/zcm/blocking.cpp
@@ -373,8 +373,6 @@ void zcm_blocking_t::recvThreadFunc()
 {
     while (recvRunning) {
         zcm_msg_t msg;
-        // XXX remove this memset once transport layers know about the utime field
-        memset(&msg, 0, sizeof(msg));
         int rc = zcm_trans_recvmsg(zt, &msg, RECV_TIMEOUT);
         if (rc == ZCM_EOK) {
             bool success;
@@ -408,7 +406,7 @@ void zcm_blocking_t::handleThreadFunc()
 void zcm_blocking_t::dispatchMsg(zcm_msg_t *msg)
 {
     zcm_recv_buf_t rbuf;
-    rbuf.recv_utime = TimeUtil::utime();
+    rbuf.recv_utime = msg->utime;
     rbuf.zcm = z;
     rbuf.data = (char*)msg->buf;
     rbuf.data_size = msg->len;

--- a/zcm/nonblocking.c
+++ b/zcm/nonblocking.c
@@ -122,7 +122,7 @@ static void dispatch_message(zcm_nonblocking_t *zcm, zcm_msg_t *msg)
             rbuf.zcm = zcm->z;
             rbuf.data = (char*)msg->buf;
             rbuf.data_size = msg->len;
-            rbuf.recv_utime = 0;
+            rbuf.recv_utime = msg->utime;
 
             sub = &zcm->subs[i];
             sub->callback(&rbuf, msg->channel, sub->usr);

--- a/zcm/transport/generic_serial_transport.h
+++ b/zcm/transport/generic_serial_transport.h
@@ -11,6 +11,7 @@ extern "C" {
 zcm_trans_t *zcm_trans_generic_serial_create(
         uint32_t (*get)(uint8_t* data, uint32_t nData, void* usr),
         uint32_t (*put)(const uint8_t* data, uint32_t nData, void* usr),
+        uint64_t (*timestamp_now)(void* usr),
         void* usr);
 
 #ifdef __cplusplus

--- a/zcm/transport/transport_nonblock_test.cpp
+++ b/zcm/transport/transport_nonblock_test.cpp
@@ -3,6 +3,8 @@
 #include "zcm/transport_register.hpp"
 #include "zcm/util/debug.h"
 
+#include "util/TimeUtil.hpp"
+
 #include <cassert>
 #include <cstring>
 
@@ -63,6 +65,7 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
         if (!used)
             return ZCM_EAGAIN;
 
+        msg->utime = TimeUtil::utime();
         msg->channel = channel;
         msg->len = messageSize;
         msg->buf = message;

--- a/zcm/transport/transport_serial.cpp
+++ b/zcm/transport/transport_serial.cpp
@@ -414,7 +414,10 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
 
                 // We got one escape char, see if it's followed by a zero
                 if (!readByte(c)) return false;
-                if (c == 0) return true;
+                if (c == 0) {
+                    msg->utime = TimeUtil::utime();
+                    return true;
+                }
             }
             return false;
         };

--- a/zcm/transport/transport_zmq_local.cpp
+++ b/zcm/transport/transport_zmq_local.cpp
@@ -7,6 +7,8 @@
 #include "zcm/util/lockfile.h"
 #include <zmq.h>
 
+#include "util/TimeUtil.hpp"
+
 #include <unistd.h>
 #include <dirent.h>
 
@@ -370,6 +372,7 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
                     //       that you will always lose the first message you get that is
                     //       larger than recvmsgBufferSize
                     int rc = zmq_recv(p.socket, recvmsgBuffer, recvmsgBufferSize, 0);
+                    msg->utime = TimeUtil::utime();
                     if (rc == -1) {
                         fprintf(stderr, "zmq_recv failed with: %s", zmq_strerror(errno));
                         // XXX: implement error handling, don't just assert

--- a/zcm/transport/udpm/udpm.cpp
+++ b/zcm/transport/udpm/udpm.cpp
@@ -377,6 +377,7 @@ int UDPM::recvmsg(zcm_msg_t *msg, int timeout)
     if (m == nullptr)
         return ZCM_EAGAIN;
 
+    msg->utime = m->utime;
     msg->channel = m->channel;
     msg->len = m->datalen;
     msg->buf = m->data;


### PR DESCRIPTION
@tkbrady Would you mind taking a look at this? It moves the responsibility of setting the utime of the received message into the transports. This is especially useful in non-blocking transports so we can get the utime closest to the start of a received message