### PR TITLE
Fixed build for later gcc versions

### DIFF
--- a/gen/emit/EmitJava.cpp
+++ b/gen/emit/EmitJava.cpp
@@ -315,8 +315,10 @@ struct EmitStruct : public Emitter
         if (zcm.gopt->wasSpecified("jdefaultpkg"))
             package += zcm.gopt->getString("jdefaultpkg");
         if (lr.structname.package.size() > 0)
+		{
             if (package != "") package += ".";
             package += lr.structname.package;
+		}
 
         emit(0, "package %s;", package.c_str());
         emit(0, " ");

--- a/gen/emit/EmitJava.cpp
+++ b/gen/emit/EmitJava.cpp
@@ -315,10 +315,10 @@ struct EmitStruct : public Emitter
         if (zcm.gopt->wasSpecified("jdefaultpkg"))
             package += zcm.gopt->getString("jdefaultpkg");
         if (lr.structname.package.size() > 0)
-		{
+        {
             if (package != "") package += ".";
             package += lr.structname.package;
-		}
+        }
 
         emit(0, "package %s;", package.c_str());
         emit(0, " ");

--- a/zcm/transport/udpm/buffers.cpp
+++ b/zcm/transport/udpm/buffers.cpp
@@ -118,16 +118,16 @@ FragBuf *MessagePool::lookupFragBuf(struct sockaddr_in *key)
     return nullptr;
 }
 
-void MessagePool::_removeFragBuf(int index)
+void MessagePool::_removeFragBuf(unsigned int index)
 {
-    assert(0 <= index && index < (int)fragbufs.size());
+    assert(0 <= index && index < (unsigned int)fragbufs.size());
 
     // Update the total_size of the fragment buffers
     FragBuf *fbuf = fragbufs[index];
     totalSize -= fbuf->buf.size;
 
     // delete old element, move last element to this slot, and shrink by 1
-    size_t lastIdx = fragbufs.size()-1;
+    unsigned int lastIdx = (unsigned int)fragbufs.size()-1;
     fragbufs[index] = fragbufs[lastIdx];
     fragbufs.resize(lastIdx);
 
@@ -139,7 +139,7 @@ void MessagePool::removeFragBuf(FragBuf *fbuf)
 {
     // NOTE: this is kinda slow...
     // Search for the fragbuf index
-    for (int idx = 0; idx < (int)fragbufs.size(); idx++)
+    for (unsigned int idx = 0; idx < fragbufs.size(); idx++)
         if (fragbufs[idx] == fbuf)
             return this->_removeFragBuf(idx);
 

--- a/zcm/transport/udpm/buffers.cpp
+++ b/zcm/transport/udpm/buffers.cpp
@@ -99,7 +99,7 @@ FragBuf *MessagePool::addFragBuf(u32 data_size)
             }
         }
         if (eldest) {
-            _removeFragBuf(idx);
+            _removeFragBuf((size_t)idx);
             // XXX Need to free the removed FragBuf*
         }
     }
@@ -118,18 +118,18 @@ FragBuf *MessagePool::lookupFragBuf(struct sockaddr_in *key)
     return nullptr;
 }
 
-void MessagePool::_removeFragBuf(unsigned int index)
+void MessagePool::_removeFragBuf(size_t index)
 {
-    assert(0 <= index && index < (unsigned int)fragbufs.size());
+    assert(index < fragbufs.size());
 
     // Update the total_size of the fragment buffers
     FragBuf *fbuf = fragbufs[index];
     totalSize -= fbuf->buf.size;
 
     // delete old element, move last element to this slot, and shrink by 1
-    unsigned int lastIdx = (unsigned int)fragbufs.size()-1;
+    size_t lastIdx = fragbufs.size()-1;
     fragbufs[index] = fragbufs[lastIdx];
-    fragbufs.resize(lastIdx);
+    fragbufs.pop_back();
 
     this->freeBuffer(fbuf->buf);
     mempool.free(fbuf);
@@ -139,7 +139,7 @@ void MessagePool::removeFragBuf(FragBuf *fbuf)
 {
     // NOTE: this is kinda slow...
     // Search for the fragbuf index
-    for (unsigned int idx = 0; idx < fragbufs.size(); idx++)
+    for (size_t idx = 0; idx < fragbufs.size(); idx++)
         if (fragbufs[idx] == fbuf)
             return this->_removeFragBuf(idx);
 

--- a/zcm/transport/udpm/buffers.hpp
+++ b/zcm/transport/udpm/buffers.hpp
@@ -171,7 +171,7 @@ struct MessagePool
 
   private:
     void _freeMessageBuffer(Message *b);
-    void _removeFragBuf(unsigned int index);
+    void _removeFragBuf(size_t index);
 
   private:
     MemPool mempool;

--- a/zcm/transport/udpm/buffers.hpp
+++ b/zcm/transport/udpm/buffers.hpp
@@ -171,7 +171,7 @@ struct MessagePool
 
   private:
     void _freeMessageBuffer(Message *b);
-    void _removeFragBuf(int index);
+    void _removeFragBuf(unsigned int index);
 
   private:
     MemPool mempool;


### PR DESCRIPTION
I'm on gcc 7.1.1 and ./waf build fails out-of-box. This commit attempts to address that.

It also somewhat accidentally exposes what appears to be a bug in gen/emit/EmitJava.cpp, where the indentation makes a line appear to be enclosed in a for loop but it isn't without adding braces.