### PR TITLE
Fix including multiple compiled types

### DIFF
--- a/examples/julia/multi_type_test.jl
+++ b/examples/julia/multi_type_test.jl
@@ -1,0 +1,40 @@
+include("../build/types/example_t.jl");
+include("../build/types/example2_t.jl");
+
+using ZCM;
+
+received_example_t = false
+function handler1(rbuf, channel::String, msg::example_t)
+    global received_example_t
+    received_example_t = true
+    println("Received example_t message on channel: ", channel)
+end
+
+received_example2_t = false
+function handler2(rbuf, channel::String, msg::example2_t)
+    global received_example2_t
+    received_example2_t = true
+    println("Received example2_t message on channel: ", channel)
+end
+
+zcm = Zcm("inproc")
+if (!good(zcm))
+    error("Unable to initialize zcm");
+end
+
+sub1 = subscribe(zcm, "EXAMPLE1", handler1, example_t)
+sub2 = subscribe(zcm, "EXAMPLE2", handler2, example2_t)
+
+start(zcm)
+publish(zcm, "EXAMPLE1", example_t())
+publish(zcm, "EXAMPLE2", example2_t())
+sleep(0.5)
+stop(zcm)
+
+unsubscribe(zcm, sub1)
+unsubscribe(zcm, sub2)
+
+@assert received_example_t "Did not receive an example_t message"
+@assert received_example2_t "Did not receive an example2_t message"
+
+println("Success!")

--- a/zcm/julia/ZCM.jl
+++ b/zcm/julia/ZCM.jl
@@ -44,6 +44,10 @@ end
 # with new methods.
 function encode end
 function decode end
+function getHash end
+function _get_hash_recursive end
+function encode_one end
+function decode_one end
 
 
 # RRR / Note: Julia requires that the memory layout of the C structs is consistent


### PR DESCRIPTION
Fixes the issues I mentioned in #163 with `getHash()` and friends. You can now include multiple type definitions without errors. 

This also fixes the type-piracy that the auto-generated `ntoh(::Array)` method was doing by eliminating that method entirely. 

This doesn't address packaging of ZCM types at all, but I still think that's important. 