### PR TITLE
Port value incorrect using udpm 

### DIFF
--- a/zcm/transport/udpm/udpmsocket.cpp
+++ b/zcm/transport/udpm/udpmsocket.cpp
@@ -125,7 +125,7 @@ bool UDPMSocket::bindPort(u16 port)
     memset(&addr, 0, sizeof (addr));
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = INADDR_ANY;
-    addr.sin_port = port;
+    addr.sin_port = htons(port);
 
     if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
         perror("bind");

--- a/zcm/transport/udpm/udpmsocket.hpp
+++ b/zcm/transport/udpm/udpmsocket.hpp
@@ -13,7 +13,7 @@ class UDPMAddress
         memset(&this->addr, 0, sizeof(this->addr));
         this->addr.sin_family = AF_INET;
         inet_aton(ip.c_str(), &this->addr.sin_addr);
-        this->addr.sin_port = port;
+        this->addr.sin_port = htons(port);
     }
 
     const string& getIP() const { return ip; }


### PR DESCRIPTION
Messages send using `udpm` transport are tranmitted with the wrong port address on little endian systems.

The port value in the `sockaddr` structure must be in **network byte order** occording to the [man page](http://man7.org/linux/man-pages/man7/ip.7.html).