### PR TITLE
Hopefully more correct cython usage

### DIFF
--- a/zcm/python/zcm.pyx
+++ b/zcm/python/zcm.pyx
@@ -6,7 +6,7 @@ cdef extern from "Python.h":
     void PyEval_InitThreads()
 
 cdef extern from "zcm/zcm.h":
-    cpdef enum zcm_return_codes:
+    cdef enum zcm_return_codes:
         ZCM_EOK,
         ZCM_EINVALID,
         ZCM_EAGAIN,


### PR DESCRIPTION
Fixed compilation bug for new versions of cython. Works with cython version 0.28.3