### PR TITLE
Fixed __STDC_VERSION__ macro, defined INLINE for __cplusplus

### DIFF
--- a/zcm/transport.h
+++ b/zcm/transport.h
@@ -189,7 +189,7 @@ extern "C" {
 #include "zcm/zcm.h"
 
 /* Only define inline for C99 builds or better */
-#if __STDC_VERSION >= 199901L
+#if (__STDC_VERSION__ >= 199901L) || (__cplusplus)
 # define INLINE inline
 #else
 # define INLINE


### PR DESCRIPTION
Changed __STDC_VERSION macro to __STDC_VERSION__ (fixing typo).
Additionally defining inline for __cplusplus builds (where __STDC_VERSION__ is not defined).

The corresponding issue: #197