### PR TITLE
installing pip with --user not working for virtual environments

### DIFF
--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -90,7 +90,7 @@ if [[ $ret -ne 0 && "$STRICT" == "true" ]]; then
     exit $ret
 fi
 
-pip install --user $PIP_PKGS
+sudo pip install $PIP_PKGS
 ret=$?
 if [[ $ret -ne 0 && "$STRICT" == "true" ]]; then
     echo "Failed to install pip packages"


### PR DESCRIPTION
pip install --user was failing due to use within virtual environments, so reverted that change.