### PR TITLE
Gen reserved type warning

### DIFF
--- a/gen/ZCMGen.cpp
+++ b/gen/ZCMGen.cpp
@@ -702,7 +702,8 @@ int ZCMGen::handleFile(const string& path, const unordered_set<string>& reserved
     } while (res == 0);
 
     for (const string& conflict : getConflictingTokens(reservedTokens))
-        fprintf(stderr, "WARNING: Token, \"%s\" is a reserved keyword\n", conflict.c_str());
+        fprintf(stderr, "WARNING (\"%s\"): Token, \"%s\" is a reserved keyword\n",
+                path.c_str(), conflict.c_str());
 
     tokenize_destroy(t);
     if (res == 0 || res == EOF)

--- a/gen/ZCMGen.cpp
+++ b/gen/ZCMGen.cpp
@@ -701,9 +701,11 @@ int ZCMGen::handleFile(const string& path, const unordered_set<string>& reserved
         res = parseEntity(*this, path, t);
     } while (res == 0);
 
+    // RRR: this actually triggers for any type that has been passed into zcmgen in this invocation
+    //      *even* ones that already created warnings
     for (const string& conflict : getConflictingTokens(reservedTokens))
-        fprintf(stderr, "WARNING (\"%s\"): Token, \"%s\" is a reserved keyword\n",
-                path.c_str(), conflict.c_str());
+        fprintf(stderr, "WARNING: Token, \"%s\" is a reserved keyword in file: \"%s\"\n",
+                conflict.c_str(), path.c_str());
 
     tokenize_destroy(t);
     if (res == 0 || res == EOF)

--- a/gen/ZCMGen.cpp
+++ b/gen/ZCMGen.cpp
@@ -667,16 +667,16 @@ ZCMStruct::getConflictingTokens(const unordered_set<string>& reservedTokens) con
     return ret;
 }
 
-unordered_set<string>
+unordered_map<const ZCMStruct*, unordered_set<string>>
 ZCMGen::getConflictingTokens(const unordered_set<string>& reservedTokens) const
 {
-    unordered_set<string> ret;
+    unordered_map<const ZCMStruct*, unordered_set<string>> ret;
     for (const auto& zstruct : structs)
-        merge(ret, zstruct.getConflictingTokens(reservedTokens));
+        ret[&zstruct] = zstruct.getConflictingTokens(reservedTokens);
     return ret;
 }
 
-int ZCMGen::handleFile(const string& path, const unordered_set<string>& reservedTokens = {})
+int ZCMGen::handleFile(const string& path)
 {
     tokenize_t* t = tokenize_create(path.c_str());
 
@@ -700,12 +700,6 @@ int ZCMGen::handleFile(const string& path, const unordered_set<string>& reserved
     do {
         res = parseEntity(*this, path, t);
     } while (res == 0);
-
-    // RRR: this actually triggers for any type that has been passed into zcmgen in this invocation
-    //      *even* ones that already created warnings
-    for (const string& conflict : getConflictingTokens(reservedTokens))
-        fprintf(stderr, "WARNING: Token, \"%s\" is a reserved keyword in file: \"%s\"\n",
-                conflict.c_str(), path.c_str());
 
     tokenize_destroy(t);
     if (res == 0 || res == EOF)

--- a/gen/ZCMGen.hpp
+++ b/gen/ZCMGen.hpp
@@ -20,6 +20,7 @@ struct ZCMTypename
     ZCMTypename(ZCMGen& zcmgen, const string& name, bool skipPrefix = false);
     void dump() const;
 
+    // Returns { conflicting tokens }
     unordered_set<string>
         getConflictingTokens(const unordered_set<string>& reservedTokens) const;
 
@@ -71,6 +72,7 @@ struct ZCMMember
     // Are all of the dimensions of this array constant? (scalars return true)
     bool isConstantSizeArray() const;
 
+    // Returns { conflicting tokens }
     unordered_set<string>
         getConflictingTokens(const unordered_set<string>& reservedTokens) const;
 
@@ -100,6 +102,7 @@ struct ZCMConstant
 
     bool isFixedPoint() const;
 
+    // Returns { conflicting tokens }
     unordered_set<string>
         getConflictingTokens(const unordered_set<string>& reservedTokens) const;
 
@@ -130,6 +133,7 @@ struct ZCMStruct
 
     u64 computeHash() const;
 
+    // Returns { conflicting tokens }
     unordered_set<string>
         getConflictingTokens(const unordered_set<string>& reservedTokens) const;
 
@@ -153,14 +157,15 @@ struct ZCMGen
     // older than the file "declaringfile"
     bool needsGeneration(const string& declaringfile, const string& outfile) const;
 
-    unordered_set<string>
+    // Returns { (const ZCMStruct*, conflicting tokens) }
+    unordered_map<const ZCMStruct*, unordered_set<string>>
         getConflictingTokens(const unordered_set<string>& reservedTokens) const;
 
     // for debugging, emit the contents to stdout
     void dump() const;
 
     // parse the provided file
-    int handleFile(const string& path, const unordered_set<string>& reservedTokens);
+    int handleFile(const string& path);
 
     // Returns true if the argument is a built-in type (e.g., "int64_t", "float").
     static bool isPrimitiveType(const string& t);


### PR DESCRIPTION
Fixes the warnings produced by zcm-gen so they do not generate extra warnings when multiple files are input to zcm-gen at the same time. Additionally informs the user of the zcmtype and filename that produced the warning.