### PR TITLE
encoded hashes shall always be big endian

### DIFF
--- a/gen/emit/EmitC.cpp
+++ b/gen/emit/EmitC.cpp
@@ -498,8 +498,7 @@ struct EmitSource : public Emit
         emit(1,    "int thislen;");
         emit(1,    "int64_t hash = __%s_get_hash();", tn_);
         emit(0,"");
-        emit(1,    "thislen = __int64_t_encode_%sarray(buf, offset + pos, maxlen - pos, &hash, 1);",
-                   zcm.gopt->getBool("little-endian-encoding") ? "little_endian_" : "");
+        emit(1,    "thislen = __int64_t_encode_array(buf, offset + pos, maxlen - pos, &hash, 1);");
         emit(1,    "if (thislen < 0) return thislen; else pos += thislen;");
         emit(0,"");
         emit(1,    "thislen = __%s_encode_array(buf, offset + pos, maxlen - pos, p, 1);", tn_);
@@ -579,8 +578,7 @@ struct EmitSource : public Emit
         emit(1,    "int64_t hash = __%s_get_hash();", tn_);
         emit(0,"");
         emit(1,    "int64_t this_hash;");
-        emit(1,    "thislen = __int64_t_decode_%sarray(buf, offset + pos, maxlen - pos, &this_hash, 1);",
-                   zcm.gopt->getBool("little-endian-encoding") ? "little_endian_" : "");
+        emit(1,    "thislen = __int64_t_decode_array(buf, offset + pos, maxlen - pos, &this_hash, 1);");
         emit(1,    "if (thislen < 0) return thislen; else pos += thislen;");
         emit(1,    "if (this_hash != hash) return -1;");
         emit(0,"");

--- a/gen/emit/EmitCpp.cpp
+++ b/gen/emit/EmitCpp.cpp
@@ -297,8 +297,7 @@ struct Emit : public Emitter
         emit(1,     "int thislen;");
         emit(1,     "int64_t hash = (int64_t)getHash();");
         emit(0, "");
-        emit(1,     "thislen = __int64_t_encode_%sarray(buf, offset + pos, maxlen - pos, &hash, 1);",
-                    zcm.gopt->getBool("little-endian-encoding") ? "little_endian_" : "");
+        emit(1,     "thislen = __int64_t_encode_array(buf, offset + pos, maxlen - pos, &hash, 1);");
         emit(1,     "if(thislen < 0) return thislen; else pos += thislen;");
         emit(0, "");
         emit(1,     "thislen = this->_encodeNoHash(buf, offset + pos, maxlen - pos);");
@@ -328,8 +327,7 @@ struct Emit : public Emitter
         emit(1,     "int thislen;");
         emit(0, "");
         emit(1,     "int64_t msg_hash;");
-        emit(1,     "thislen = __int64_t_decode_%sarray(buf, offset + pos, maxlen - pos, &msg_hash, 1);",
-                    zcm.gopt->getBool("little-endian-encoding") ? "little_endian_" : "");
+        emit(1,     "thislen = __int64_t_decode_array(buf, offset + pos, maxlen - pos, &msg_hash, 1);");
         emit(1,     "if (thislen < 0) return thislen; else pos += thislen;");
         emit(1,     "if (msg_hash != getHash()) return -1;");
         emit(0, "");

--- a/gen/emit/EmitJulia.cpp
+++ b/gen/emit/EmitJulia.cpp
@@ -530,7 +530,7 @@ struct EmitJuliaType : public Emitter
 
         emit(0, "function ZCM.encode(msg::%s)", sn);
         emit(1,     "buf = IOBuffer()");
-        emit(1,     "write(buf, %s(ZCM.getHash(%s)))", hton.c_str(), sn);
+        emit(1,     "write(buf, hton(ZCM.getHash(%s)))", sn);
         emit(1,     "ZCM._encode_one(msg, buf)");
         emit(1,     "return ZCM._takebuf_array(buf);");
         emit(0, "end");
@@ -686,8 +686,7 @@ struct EmitJuliaType : public Emitter
 
         emit(0, "function ZCM.decode(::Type{%s}, data::Vector{UInt8})", sn);
         emit(1,     "buf = IOBuffer(data)");
-        emit(1,     "if %s(reinterpret(Int64, read(buf, 8))[1]) != ZCM.getHash(%s)",
-                ntoh.c_str(), sn);
+        emit(1,     "if ntoh(reinterpret(Int64, read(buf, 8))[1]) != ZCM.getHash(%s)", sn);
         emit(2,         "throw(\"Decode error\")");
         emit(1,     "end");
         emit(1,     "return ZCM._decode_one(%s, buf)", sn);


### PR DESCRIPTION
While little-endian types are not widespread, we do support them in a couple languages. In those cases, having the zcmtype hash encoded little-endian breaks anything that is trying to determine which type is to be decoded by using a hash lookup. By changing the hash to be encoded big-endian always, this problem goes away.