### PR TITLE
Select interface for UDP transport

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -37,9 +37,9 @@ be used to *summon* the transport:
     <td><code>  zcm_create("nonblock-inproc")                           </code></td>
   </tr>
   <tr>
-    <td>        UDP Multicast                                           </td>
-    <td><code>  udpm://&lt;udpm-ipaddr&gt;:&lt;port&gt;?ttl=&lt;ttl&gt; </code></td>
-    <td><code>  zcm_create("udpm://239.255.76.67:7667?ttl=0")           </code></td>
+    <td>        UDP Multicast                                                             </td>
+    <td><code>  udpm://&lt;udpm-ipaddr&gt;:&lt;port&gt;?ttl=&lt;ttl&gt;&if=&lt;ifaddr&gt; </code></td>
+    <td><code>  zcm_create("udpm://239.255.76.67:7667?ttl=0&if=192.168.0.1")              </code></td>
   </tr>
   <tr>
     <td>        Serial                                                  </td>
@@ -50,6 +50,8 @@ be used to *summon* the transport:
 
 When no url is provided (i.e. `zcm_create(NULL)`), the `ZCM_DEFAULT_URL` environment variable is
 queried for a valid url.
+
+> The **if=&lt;ifaddr&gt;** option for `udpm` transports allows the selection of a specific ethernet interface.
 
 ## Custom Transports
 

--- a/zcm/transport/udpm/udpmsocket.hpp
+++ b/zcm/transport/udpm/udpmsocket.hpp
@@ -36,7 +36,8 @@ class UDPMSocket
     void close();
 
     bool init();
-    bool joinMulticastGroup(struct in_addr multiaddr);
+    bool setMulticastInterface(struct in_addr ifaddr);
+    bool joinMulticastGroup(struct in_addr multiaddr, struct in_addr ifaddr);
     bool setTTL(u8 ttl);
     bool bindPort(u16 port);
     bool setReuseAddr();
@@ -61,8 +62,8 @@ class UDPMSocket
     static bool checkConnection(const string& ip, u16 port);
     void checkAndWarnAboutSmallBuffer(size_t datalen, size_t kbufsize);
 
-    static UDPMSocket createSendSocket(struct in_addr multiaddr, u8 ttl);
-    static UDPMSocket createRecvSocket(struct in_addr multiaddr, u16 port);
+    static UDPMSocket createSendSocket(struct in_addr multiaddr, u8 ttl, struct in_addr ifaddr);
+    static UDPMSocket createRecvSocket(struct in_addr multiaddr, u16 port, struct in_addr ifaddr);
 
   private:
     SOCKET fd = -1;


### PR DESCRIPTION
Often it would be useful to select the interface that the UDP transport connects to. This PR adds this support and the required documentation. Would be awesome if you could merge it soon.