### PR TITLE
Revert "Merge pull request #280 from ZeroCM/trns-ipc_slashes"

### DIFF
--- a/examples/cpp/Pub.cpp
+++ b/examples/cpp/Pub.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
     my_data.enabled = true;
 
     while (1) {
-        zcm.publish("EXAMPLE/Test", &my_data);
+        zcm.publish("EXAMPLE", &my_data);
         for (auto& val : my_data.position) val++;
         usleep(1000*1000);
     }

--- a/examples/cpp/Sub.cpp
+++ b/examples/cpp/Sub.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
         return 1;
 
     Handler handlerObject;
-    zcm.subscribe("EXAMPLE/Test", &Handler::handleMessage, &handlerObject);
+    zcm.subscribe("EXAMPLE", &Handler::handleMessage, &handlerObject);
     zcm.subscribe("FOOBAR", &Handler::handleMessage, &handlerObject);
     zcm.run();
 

--- a/util/FileUtil.hpp
+++ b/util/FileUtil.hpp
@@ -32,24 +32,21 @@ namespace FileUtil
         return ::rename(old.c_str(), new_.c_str());
     }
 
-    static inline int mkdirWithParents(const string& path, mode_t mode)
+    static inline void mkdirWithParents(const string& path, mode_t mode)
     {
-        auto parts = StringUtil::split(path, '/');
-        string dirPath = "";
-        for (size_t i = 0; i < parts.size(); ++i) {
-            const auto& p = parts[i];
-            if (p == "") {
-                dirPath += "/";
-                continue;
+        for (size_t i = 0; i < path.size(); i++) {
+            if (path[i]=='/') {
+                char *dirpath = (char *) malloc(i+1);
+                strncpy(dirpath, path.c_str(), i);
+                dirpath[i] = '\0';
+
+                mkdir(dirpath, mode);
+                free(dirpath);
+
+                i++; // skip the '/'
             }
-            dirPath += p;
-            int err = mkdir(dirPath.c_str(), mode);
-            if (err < 0 && errno != EEXIST) {
-                return err;
-            }
-            dirPath += "/";
         }
-        return 0;
+        mkdir(path.c_str(), mode);
     }
 
     static inline string dirname(const string& path)
@@ -61,8 +58,8 @@ namespace FileUtil
         return ret;
     }
 
-    static int makeDirsForFile(const string& path)
+    static void makeDirsForFile(const string& path)
     {
-        return mkdirWithParents(dirname(path), 0755);
+        mkdirWithParents(dirname(path), 0755);
     }
 }

--- a/zcm/transport/transport_zmq_local.cpp
+++ b/zcm/transport/transport_zmq_local.cpp
@@ -8,7 +8,6 @@
 #include <zmq.h>
 
 #include "util/TimeUtil.hpp"
-#include "util/FileUtil.hpp"
 
 #include <unistd.h>
 #include <dirent.h>
@@ -33,7 +32,6 @@ using namespace std;
 #define START_BUF_SIZE (1 << 20)
 #define ZMQ_IO_THREADS 1
 #define IPC_NAME_PREFIX "zcm-channel-zmq-ipc-"
-#define IPC_NAME_PREFIX_LEN (sizeof(IPC_NAME_PREFIX) - 1)
 
 enum Type { IPC, INPROC, };
 
@@ -122,20 +120,13 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
         delete[] recvmsgBuffer;
     }
 
-    string getPath(const string& channel)
-    {
-        return "/tmp/" +
-               (subnet == "" ? + "" : (subnet + "/")) +
-               IPC_NAME_PREFIX + channel;
-    }
-
     string getAddress(const string& channel)
     {
         switch (type) {
             case IPC:
-                return "ipc://" + getPath(channel);
+                return "ipc:///tmp/" + subnet + "/" + IPC_NAME_PREFIX + channel;
             case INPROC:
-                return "inproc://" + getPath(channel);
+                return "inproc://" + subnet + "/" + IPC_NAME_PREFIX + channel;
         }
         assert(0 && "unreachable");
     }
@@ -158,15 +149,6 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
             ZCM_DEBUG("failed to create pubsock: %s", zmq_strerror(errno));
             return nullptr;
         }
-
-        string path = getPath(channel);
-        ZCM_DEBUG("Path: %s", path.c_str());
-        int err = FileUtil::makeDirsForFile(path);
-        if (err < 0 && errno != EEXIST) {
-            ZCM_DEBUG("Unable to create directory for socket bind: %s", path.c_str());
-            return nullptr;
-        }
-
         string address = getAddress(channel);
         int rc = zmq_bind(sock, address.c_str());
         if (rc == -1) {
@@ -206,31 +188,20 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
         return sock;
     }
 
-    void ipcScanForNewChannels(const string& dirname = "")
+    void ipcScanForNewChannels()
     {
-        string abspath = "/tmp/" +
-                         (subnet == "" ? subnet : (subnet + "/")) +
-                         dirname;
+        const char *prefix = IPC_NAME_PREFIX;
+        size_t prefixLen = strlen(IPC_NAME_PREFIX);
+
         DIR *d;
         dirent *ent;
 
-        if (!(d = opendir(abspath.c_str())))
+        if (!(d=opendir(string("/tmp/" + subnet).c_str())))
             return;
 
-        while ((ent = readdir(d)) != nullptr) {
-            string dname = ent->d_name;
-            if (dname == ".." || dname == ".")
-                continue;
-
-            string path = (dirname == "" ? "" : (dirname + "/")) + dname;
-
-            if (ent->d_type == DT_DIR) {
-                ipcScanForNewChannels(path);
-                continue;
-            }
-
-            if (strncmp(path.c_str(), IPC_NAME_PREFIX, IPC_NAME_PREFIX_LEN) == 0) {
-                string channel(path.c_str() + IPC_NAME_PREFIX_LEN);
+        while ((ent=readdir(d)) != nullptr) {
+            if (strncmp(ent->d_name, prefix, prefixLen) == 0) {
+                string channel(ent->d_name + prefixLen);
                 void *sock = subsockFindOrCreate(channel, false);
                 if (sock == nullptr) {
                     ZCM_DEBUG("failed to open subsock in scanForNewChannels(%s)",
@@ -238,6 +209,7 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
                 }
             }
         }
+
         closedir(d);
     }
 

--- a/zcm/util/lockfile.cpp
+++ b/zcm/util/lockfile.cpp
@@ -1,6 +1,5 @@
 #include "zcm/util/lockfile.h"
 #include "zcm/util/debug.h"
-#include "util/FileUtil.hpp"
 
 #include <stdlib.h>
 #include <sys/types.h>
@@ -12,7 +11,6 @@
 
 #include <cstring>
 #include <string>
-
 using namespace std;
 
 #define DEFAULT_LOCK_DIR "/var/lock/zcm"
@@ -34,8 +32,16 @@ static string makeLockfilePath(const string& name)
 
     const char* dir = std::getenv("ZCM_LOCK_DIR");
     if (dir) ret = dir;
+
+    int err = mkdir(ret.c_str(), S_IRWXO | S_IRWXG | S_IRWXU);
+    if (err < 0 && errno != EEXIST) {
+        ZCM_DEBUG("Unable to create lockfile directory");
+        return "";
+    }
+
     if (ret == "") return ret;
-    if (ret.back() != '/') ret += "/";
+
+    if (ret[ret.size() - 1] != '/') ret += "/";
 
     ret += LOCK_PREFIX;
 
@@ -44,15 +50,11 @@ static string makeLockfilePath(const string& name)
         idx = 5;
     for (; idx < name.size(); idx++) {
         auto c = name[idx];
-        ret += string(1, c);
+        if (c == '/')
+            ret += string(1, '_');
+        else
+            ret += string(1, c);
     }
-
-    int err = FileUtil::makeDirsForFile(ret);
-    if (err < 0 && errno != EEXIST) {
-        ZCM_DEBUG("Unable to create lockfile directory: %s", ret.c_str());
-        return "";
-    }
-
     return ret;
 }
 


### PR DESCRIPTION
This reverts commit 4fbfbe10f7b7fb61c1b83ee88905643211b488e2, reversing
changes made to 84389fe59455c507b513422984e502515272e24c.

Unfortunately, the support for ipc slashes support somehow destroyed the performance of ipc zcm in when publishing a lot of messages. I'm seeing super high cpu usage by a zcm-logger instance and 60% - 70% missed messages across the board (even though I'm not using any subnets with slashes). Hoping that @jbendes can come back and look over what actually broke things, but for the time being we have to revert this.