### PR TITLE
added constants to tell if the type was generated in little endian mode

### DIFF
--- a/examples/julia/little_endian.jl
+++ b/examples/julia/little_endian.jl
@@ -28,6 +28,8 @@ sub2 = subscribe(zcm, "EXAMPLE", untyped_handler)
 
 msg = little_endian_t()
 
+@assert (msg.IS_LITTLE_ENDIAN == 1) "Type must be little endian"
+
 start(zcm)
 
 msg.timestamp = 0;

--- a/gen/Main.cpp
+++ b/gen/Main.cpp
@@ -62,6 +62,7 @@ int main(int argc, char* argv[])
             return res;
 
     unordered_set<string> reservedTokens;
+    reservedTokens.insert("IS_LITTLE_ENDIAN");
     merge(reservedTokens, getReservedKeywordsC());
     merge(reservedTokens, getReservedKeywordsCpp());
     merge(reservedTokens, getReservedKeywordsJava());

--- a/gen/emit/EmitC.cpp
+++ b/gen/emit/EmitC.cpp
@@ -161,6 +161,8 @@ struct EmitHeader : public Emit
         }
 
         // output constants
+        emit(0, "#define %s_IS_LITTLE_ENDIAN %s", tnUpper.c_str(),
+                zcm.gopt->getBool("little-endian-encoding") ? "1" : "0");
         for (auto& zc : zs.constants) {
             assert(ZCMGen::isLegalConstType(zc.type));
             string suffix = (zc.type == "int64_t") ? "LL" : "";

--- a/gen/emit/EmitCpp.cpp
+++ b/gen/emit/EmitCpp.cpp
@@ -207,6 +207,8 @@ struct Emit : public Emitter
         if (zs.constants.size() > 0) {
             emit(1, "public:");
             emit(2, "#if __cplusplus > 199711L /* if c++11 */");
+            emit(2, "static constexpr %-8s IS_LITTLE_ENDIAN = %s;", "int8_t",
+                    zcm.gopt->getBool("little-endian-encoding") ? "1" : "0");
             for (auto& zc : zs.constants) {
                 assert(ZCMGen::isLegalConstType(zc.type));
                 emitComment(2, zc.comment);
@@ -216,6 +218,8 @@ struct Emit : public Emitter
                         zc.membername.c_str(), zc.valstr.c_str(), suffix);
             }
             emit(2, "#else");
+            emit(2, "static const     %-8s IS_LITTLE_ENDIAN = %s;", "int8_t",
+                    zcm.gopt->getBool("little-endian-encoding") ? "1" : "0");
             for (auto& zc : zs.constants) {
                 assert(ZCMGen::isLegalConstType(zc.type));
                 string mt = mapTypeName(zc.type);

--- a/gen/emit/EmitJava.cpp
+++ b/gen/emit/EmitJava.cpp
@@ -381,8 +381,8 @@ struct EmitStruct : public Emitter
         //////////////////////////////////////////////////////////////
         // CONSTANTS
 
-        emit(1, "public static final byte IS_LITTLE_ENDIAN = (byte) %s;",
-                zcm.gopt->getBool("little-endian-encoding") ? "1" : "0");
+        emit(1, "public static final boolean IS_LITTLE_ENDIAN = %s;",
+                zcm.gopt->getBool("little-endian-encoding") ? "true" : "false");
         for (auto& zc : zs.constants) {
             assert(ZCMGen::isLegalConstType(zc.type));
 

--- a/gen/emit/EmitJava.cpp
+++ b/gen/emit/EmitJava.cpp
@@ -380,6 +380,9 @@ struct EmitStruct : public Emitter
 
         //////////////////////////////////////////////////////////////
         // CONSTANTS
+
+        emit(1, "public static final byte IS_LITTLE_ENDIAN = (byte) %s;",
+                zcm.gopt->getBool("little-endian-encoding") ? "1" : "0");
         for (auto& zc : zs.constants) {
             assert(ZCMGen::isLegalConstType(zc.type));
 

--- a/gen/emit/EmitJulia.cpp
+++ b/gen/emit/EmitJulia.cpp
@@ -221,6 +221,7 @@ struct EmitJuliaType : public Emitter
             emit(1, "# **********************");
             emit(1, "# Constants");
             emit(1, "# **********************\n");
+            emit(1, "%-30s::Bool", "IS_LITTLE_ENDIAN");
             for (auto& zc : zs.constants) {
                 assert(ZCMGen::isLegalConstType(zc.type));
                 string mt = mapTypeName(zc.type);
@@ -254,6 +255,9 @@ struct EmitJuliaType : public Emitter
             emit(2, "# **********************");
             emit(2, "# Constants");
             emit(2, "# **********************\n");
+
+            emit(2, "self.IS_LITTLE_ENDIAN::Bool = %s",
+                    zcm.gopt->getBool("little-endian-encoding") ? "true" : "false");
 
             for (auto& zc : zs.constants) {
                 assert(ZCMGen::isLegalConstType(zc.type));

--- a/gen/emit/EmitNode.cpp
+++ b/gen/emit/EmitNode.cpp
@@ -628,6 +628,9 @@ struct EmitModule : public Emitter
 
     void emitConstants(const ZCMStruct& zs, const string& prefix, size_t indent = 0)
     {
+        emit(indent, "%s.IS_LITTLE_ENDIAN = %s;", prefix.c_str(),
+                     zcm.gopt->getBool("little-endian-encoding") ? "true" : "false");
+
         for (size_t i = 0; i < zs.constants.size(); ++i) {
             static string hexPrefix = "0x";
             if (zs.constants[i].type == "int64_t") {

--- a/gen/emit/EmitPython.cpp
+++ b/gen/emit/EmitPython.cpp
@@ -68,6 +68,8 @@ struct PyEmitStruct : public Emitter
         emit(0, "");
 
         // CONSTANTS
+        emit(1, "IS_LITTLE_ENDIAN = %s;",
+                zcm.gopt->getBool("little-endian-encoding") ? "True" : "False");
         for (auto& zc : zs.constants) {
             assert(ZCMGen::isLegalConstType(zc.type));
             emit(1, "%s = %s", zc.membername.c_str(), zc.valstr.c_str());


### PR DESCRIPTION
Added constants to all generated zcmtypes to tell the user if it's been generated in little endian mode or not.

@jbendes can you take a look at this