### PR TITLE
Introspectively decoding encoded zcmtypes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: env
         run: |
-            echo "::add-path::$(pwd)/deps/julia/bin"
-            echo "::add-path::/home/runner/.local/bin"
+            echo "{$(pwd)/deps/julia/bin}" >> $GITHUB_PATH
+            echo "{/home/runner/.local/bin}" >> $GITHUB_PATH
       - name: prefix
         run: |
             mkdir -p ../tmp/x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,13 @@ jobs:
         shell: bash -l {0}
     env:
         PYTHON: /usr/bin/python3
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     steps:
       - uses: actions/checkout@v2
       - name: env
         run: |
-            echo "{$(pwd)/deps/julia/bin}" >> $GITHUB_PATH
-            echo "{/home/runner/.local/bin}" >> $GITHUB_PATH
+            echo "::add-path::$(pwd)/deps/julia/bin"
+            echo "::add-path::/home/runner/.local/bin"
       - name: prefix
         run: |
             mkdir -p ../tmp/x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
         uses: actions/checkout@v2
       - name: env
         run: |
-            echo "::add-path::$(pwd)/deps/julia/bin"
-            echo "::add-path::/home/runner/.local/bin"
+            echo "{$(pwd)/deps/julia/bin}" >> $GITHUB_PATH
+            echo "{/home/runner/.local/bin}" >> $GITHUB_PATH
       - name: deps
         run: ./scripts/install-deps.sh -i -s
       - name: Build Deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,14 @@ jobs:
         shell: bash -l {0}
     env:
         PYTHON: /usr/bin/python3
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: env
         run: |
-            echo "{$(pwd)/deps/julia/bin}" >> $GITHUB_PATH
-            echo "{/home/runner/.local/bin}" >> $GITHUB_PATH
+            echo "::add-path::$(pwd)/deps/julia/bin"
+            echo "::add-path::/home/runner/.local/bin"
       - name: deps
         run: ./scripts/install-deps.sh -i -s
       - name: Build Deb


### PR DESCRIPTION
Spy lite can now introspectively decode zcmtypes encoded inside other zcmtypes. It checks all byte array fields to see if they are actually zcmtypes by doing a hash check.