### PR TITLE
Accidental message truncate bug

### DIFF
--- a/zcm/python/zerocm.pyx
+++ b/zcm/python/zerocm.pyx
@@ -132,7 +132,7 @@ cdef class ZCM:
         return zcm_publish(self.zcm, channel.encode('utf-8'), data, len(_data) * sizeof(uint8_t))
     def publish_raw(self, str channel, bytes data):
         cdef const uint8_t* _data = data
-        return zcm_publish(self.zcm, channel.encode('utf-8'), _data, len(_data) * sizeof(uint8_t))
+        return zcm_publish(self.zcm, channel.encode('utf-8'), _data, len(data) * sizeof(uint8_t))
     def flush(self):
         while zcm_try_flush(self.zcm) != ZCM_EOK:
             time.sleep(0) # yield the gil


### PR DESCRIPTION
Python bindings were accidentally truncating published messages due to a message length calculation that was using a cstring length instead of the data length