### PR TITLE
Move optFind from udpm.cpp into common url.cpp

### DIFF
--- a/zcm/transport/udpm/udpm.cpp
+++ b/zcm/transport/udpm/udpm.cpp
@@ -480,14 +480,6 @@ zcm_trans_methods_t ZCM_TRANS_CLASSNAME::methods = {
     &ZCM_TRANS_CLASSNAME::_destroy,
 };
 
-static const char *optFind(zcm_url_opts_t *opts, const string& key)
-{
-    for (size_t i = 0; i < opts->numopts; i++)
-        if (key == opts->name[i])
-            return opts->value[i];
-    return NULL;
-}
-
 // TODO: this probably belongs more in a string util like file
 #include <sstream>
 static vector<string> split(const string& str, char delimiter)
@@ -518,7 +510,7 @@ static zcm_trans_t *createUdpm(zcm_url_t *url)
     auto& port = parts[1];
 
     auto *opts = zcm_url_opts(url);
-    auto *ttl = optFind(opts, "ttl");
+    auto *ttl = zcm_url_opt_find(opts, "ttl");
     if (!ttl) {
         ZCM_DEBUG("No ttl specified. Using default ttl=0");
         ttl = "0";

--- a/zcm/url.cpp
+++ b/zcm/url.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 
 // TODO: this probably belongs more in a string util like file
-static vector<string> split(const string& str, char delimiter)
+vector<string> split(const string& str, char delimiter)
 {
     vector<string> v;
     std::stringstream ss {str};
@@ -118,5 +118,12 @@ const char *zcm_url_address(zcm_url_t *u)
 { return u->address.c_str(); }
 zcm_url_opts_t *zcm_url_opts(zcm_url_t *u)
 { return u->getZopts(); }
+const char *zcm_url_opt_find(zcm_url_opts_t *opts, const char *key)
+{
+    for (size_t i = 0; i < opts->numopts; i++)
+        if (key == opts->name[i])
+            return opts->value[i];
+    return nullptr;
+}
 
 }

--- a/zcm/url.cpp
+++ b/zcm/url.cpp
@@ -9,7 +9,7 @@
 using namespace std;
 
 // TODO: this probably belongs more in a string util like file
-vector<string> split(const string& str, char delimiter)
+static vector<string> split(const string& str, char delimiter)
 {
     vector<string> v;
     std::stringstream ss {str};

--- a/zcm/url.h
+++ b/zcm/url.h
@@ -23,6 +23,7 @@ void zcm_url_destroy(zcm_url_t *u);
 const char *zcm_url_protocol(zcm_url_t *u);
 const char *zcm_url_address(zcm_url_t *u);
 zcm_url_opts_t *zcm_url_opts(zcm_url_t *u);
+const char *zcm_url_opt_find(zcm_url_opts_t *opts, const char *key);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
thought the optFind function was handy, wanted to move it out of its hidey hole in udpm.cpp and into url.h/url.cpp