### PR TITLE
Trns regex

### DIFF
--- a/examples/cpp/Pub.cpp
+++ b/examples/cpp/Pub.cpp
@@ -8,6 +8,9 @@ int main(int argc, char *argv[])
     if (!zcm.good())
         return 1;
 
+    std::string channel = "EXAMPLE";
+    if (argc > 1) channel = argv[1];
+
     example_t my_data {};
     my_data.timestamp = 0;
 
@@ -30,7 +33,7 @@ int main(int argc, char *argv[])
     my_data.enabled = true;
 
     while (1) {
-        zcm.publish("EXAMPLE", &my_data);
+        zcm.publish(channel, &my_data);
         for (auto& val : my_data.position) val++;
         usleep(1000*1000);
     }

--- a/test/zcm/SubUnsubCPPTest.hpp
+++ b/test/zcm/SubUnsubCPPTest.hpp
@@ -64,7 +64,7 @@ class SubUnsubCPPTest : public CxxTest::TestSuite
     void tearDown() override {}
 
     void testPubSub() {
-        size_t sleep_time = 200000;
+        size_t sleep_time = 5e5;
 
         Handler handler;
 

--- a/test/zcm/TransTest.hpp
+++ b/test/zcm/TransTest.hpp
@@ -90,7 +90,7 @@ static void recv()
         exit(1);
 
     // Tell the transport to give us all of the channels
-    zcm_trans_recvmsg_enable(trans, NULL, true);
+    zcm_trans_recvmsg_enable(trans, ".*", true);
 
     zcm_msg_t master = makeMasterMsg();
 //    uint64_t start = TimeUtil::utime();

--- a/test/zcm/TransTest.hpp
+++ b/test/zcm/TransTest.hpp
@@ -76,7 +76,7 @@ static void send()
     zcm_msg_t msg = makeMasterMsg();
     // For transports that require a "warm up" message
     zcm_trans_sendmsg(trans, msg);
-    usleep(5e5);
+    usleep(1e6);
 
     for (int i = 0; i < 3 * MSG_COUNT && running_send; i++) {
         zcm_trans_sendmsg(trans, msg);
@@ -101,22 +101,24 @@ static void recv()
 
 //    uint64_t start = TimeUtil::utime();
 
-    for (i = 0; i < MSG_COUNT && running_recv; i++) {
+    for (i = 0; i < MSG_COUNT && running_recv;) {
         zcm_msg_t msg;
         int ret = zcm_trans_recvmsg(trans, &msg, 100);
         if (ret == ZCM_EOK) {
             verifySame(&master, &msg);
+            ++i;
         }
     }
 
     zcm_trans_recvmsg_enable(trans, master.channel, true);
     zcm_trans_recvmsg_enable(trans, master.channel, false);
 
-    for (i = 0; i < MSG_COUNT && running_recv; i++) {
+    for (i = 0; i < MSG_COUNT && running_recv;) {
         zcm_msg_t msg;
         int ret = zcm_trans_recvmsg(trans, &msg, 100);
         if (ret == ZCM_EOK) {
             verifySame(&master, &msg);
+            ++i;
         }
     }
 

--- a/tools/cpp/spy-lite/main.cpp
+++ b/tools/cpp/spy-lite/main.cpp
@@ -369,6 +369,8 @@ struct Args
             };
         }
 
+        if (channels.empty()) channels.push_back(".*");
+
         return true;
     }
 

--- a/tools/cpp/spy-lite/main.cpp
+++ b/tools/cpp/spy-lite/main.cpp
@@ -342,16 +342,18 @@ struct Args
 {
     const char *zcmurl = nullptr;
     const char *zcmtypes_path = nullptr;
+    vector<string> channels;
     bool debug = false;
 
     bool parse(int argc, char *argv[])
     {
         // set some defaults
-        const char *optstring = "hu:p:d";
+        const char *optstring = "hu:p:c:d";
         struct option long_opts[] = {
             { "help",            no_argument, 0, 'h' },
             { "zcm-url",   required_argument, 0, 'u' },
             { "type-path", required_argument, 0, 'p' },
+            { "channel",   required_argument, 0, 'c' },
             { "debug",           no_argument, 0, 'd' },
             { 0, 0, 0, 0 }
         };
@@ -362,6 +364,7 @@ struct Args
                 case 'u': zcmurl        = optarg; break;
                 case 'd': debug         = true;   break;
                 case 'p': zcmtypes_path = optarg; break;
+                case 'c': channels.push_back(optarg); break;
                 case 'h': default: usage(); return false;
             };
         }
@@ -383,6 +386,7 @@ struct Args
                 "  -h, --help                 Shows this help text and exits\n"
                 "  -u, --zcm-url=URL          Log messages on the specified ZCM URL\n"
                 "  -p, --type-path=PATH       Path to a shared library containing the zcmtypes\n"
+                "  -c, --channel=CHANNEL      Channel to subscribe to. Can be specified more than once\n"
                 "  -d, --debug                Run a dry run to ensure proper spy setup\n"
                 "\n");
     }
@@ -430,7 +434,9 @@ int main(int argc, char *argv[])
                         "-u opt or setting the ZCM_DEFAULT_URL envvar\n");
         return 1;
     }
-    zcm_subscribe(zcm, ".*", handler_all_zcm, &spy);
+    for (auto channel : args.channels) {
+        zcm_subscribe(zcm, channel.c_str(), handler_all_zcm, &spy);
+    }
     zcm_start(zcm);
 
     thread printThread {printThreadFunc, &spy};

--- a/wscript
+++ b/wscript
@@ -320,6 +320,7 @@ def setup_environment_asan(ctx):
              '-fsanitize=address',    # AddressSanitizer, a memory error detector.
              '-fsanitize=integer',    # Enables checks for undefined or suspicious integer behavior.
              '-fsanitize=undefined',  # Fast and compatible undefined behavior checker.
+             '-Wno-deprecated-declarations', # Bug in cython/clang
     ]
 
     ctx.env.CFLAGS_default    += FLAGS
@@ -331,6 +332,7 @@ def setup_environment_tsan(ctx):
 
     FLAGS = ['-fcolor-diagnostics',
              '-fsanitize=thread',     # ThreadSanitizer, a data race detector.
+             '-Wno-deprecated-declarations', # Bug in cython/clang
     ]
 
     ctx.env.CFLAGS_default    += FLAGS

--- a/zcm/nonblocking.c
+++ b/zcm/nonblocking.c
@@ -105,28 +105,25 @@ zcm_sub_t* zcm_nonblocking_subscribe(zcm_nonblocking_t* zcm, const char* channel
     if (rc != ZCM_EOK) return NULL;
 
     for (i = 0; i <= zcm->subInUseEnd && i < ZCM_NONBLOCK_SUBS_MAX; ++i) {
-        if (!zcm->subInUse[i]) {
+        if (zcm->subInUse[i]) continue;
 
-            strncpy(zcm->subs[i].channel, channel, ZCM_CHANNEL_MAXLEN);
-            zcm->subs[i].channel[ZCM_CHANNEL_MAXLEN] = '\0';
+        strncpy(zcm->subs[i].channel, channel, ZCM_CHANNEL_MAXLEN);
+        zcm->subs[i].channel[ZCM_CHANNEL_MAXLEN] = '\0';
+        zcm->subs[i].callback = cb;
+        zcm->subs[i].usr = usr;
 
-            size_t clen = strlen(zcm->subs[i].channel);
-
-            zcm->subs[i].callback = cb;
-            zcm->subs[i].usr = usr;
-            zcm->subIsRegex[i] = isRegexChannel(zcm->subs[i].channel, clen);
-
-            if (zcm->subIsRegex[i] &&
-                !isSupportedRegex(zcm->subs[i].channel, clen)) {
-                return NULL;
-            }
-
-            zcm->subInUse[i] = true;
-
-            if (i == zcm->subInUseEnd) ++zcm->subInUseEnd;
-
-            return &zcm->subs[i];
+        size_t clen = strlen(zcm->subs[i].channel);
+        zcm->subIsRegex[i] = isRegexChannel(zcm->subs[i].channel, clen);
+        if (zcm->subIsRegex[i] &&
+            !isSupportedRegex(zcm->subs[i].channel, clen)) {
+            return NULL;
         }
+
+        zcm->subInUse[i] = true;
+
+        if (i == zcm->subInUseEnd) ++zcm->subInUseEnd;
+
+        return &zcm->subs[i];
     }
     return NULL;
 }

--- a/zcm/nonblocking.c
+++ b/zcm/nonblocking.c
@@ -19,6 +19,7 @@ struct zcm_nonblocking
     /* TODO speed this up */
     zcm_sub_t subs[ZCM_NONBLOCK_SUBS_MAX];
     bool      subInUse[ZCM_NONBLOCK_SUBS_MAX];
+    bool      subIsRegex[ZCM_NONBLOCK_SUBS_MAX];
     size_t    subInUseEnd;
 };
 
@@ -52,6 +53,7 @@ static bool isSupportedRegex(const char* c, size_t clen)
 
     return true;
 }
+
 
 int zcm_nonblocking_try_create(zcm_nonblocking_t** zcm, zcm_t* z, zcm_trans_t* zt)
 {
@@ -98,19 +100,7 @@ zcm_sub_t* zcm_nonblocking_subscribe(zcm_nonblocking_t* zcm, const char* channel
     int rc;
     size_t i;
 
-    size_t clen = strlen(channel);
-    bool regex = isRegexChannel(channel, clen);
-    if (regex) {
-        if (!isSupportedRegex(channel, clen)) return NULL;
-        if (!zcm->allChannelsEnabled) {
-            rc = zcm_trans_recvmsg_enable(zcm->zt, NULL, true);
-            zcm->allChannelsEnabled = true;
-        } else {
-            rc = ZCM_EOK;
-        }
-    } else {
-        rc = zcm_trans_recvmsg_enable(zcm->zt, channel, true);
-    }
+    rc = zcm_trans_recvmsg_enable(zcm->zt, channel, true);
 
     if (rc != ZCM_EOK) return NULL;
 
@@ -119,8 +109,18 @@ zcm_sub_t* zcm_nonblocking_subscribe(zcm_nonblocking_t* zcm, const char* channel
 
             strncpy(zcm->subs[i].channel, channel, ZCM_CHANNEL_MAXLEN);
             zcm->subs[i].channel[ZCM_CHANNEL_MAXLEN] = '\0';
+
+            size_t clen = strlen(zcm->subs[i].channel);
+
             zcm->subs[i].callback = cb;
             zcm->subs[i].usr = usr;
+            zcm->subIsRegex[i] = isRegexChannel(zcm->subs[i].channel, clen);
+
+            if (zcm->subIsRegex[i] &&
+                !isSupportedRegex(zcm->subs[i].channel, clen)) {
+                return NULL;
+            }
+
             zcm->subInUse[i] = true;
 
             if (i == zcm->subInUseEnd) ++zcm->subInUseEnd;
@@ -134,8 +134,6 @@ zcm_sub_t* zcm_nonblocking_subscribe(zcm_nonblocking_t* zcm, const char* channel
 int zcm_nonblocking_unsubscribe(zcm_nonblocking_t* zcm, zcm_sub_t* sub)
 {
     size_t i;
-    size_t clen;
-    bool regex;
     int match_idx = sub - zcm->subs;
     bool lastChanSub = true;
     int rc = ZCM_EOK;
@@ -143,34 +141,19 @@ int zcm_nonblocking_unsubscribe(zcm_nonblocking_t* zcm, zcm_sub_t* sub)
     if (match_idx < 0 || match_idx >= zcm->subInUseEnd) return ZCM_EINVALID;
     if (!zcm->subInUse[match_idx]) return ZCM_EINVALID;
 
-    clen = strlen(sub->channel);
-    regex = isRegexChannel(sub->channel, clen);
-    if (regex) {
-        for (i = 0; i < zcm->subInUseEnd; ++i) {
-            if (!zcm->subInUse[i]) continue;
-            if (match_idx != i &&
-                isRegexChannel(zcm->subs[i].channel, strlen(zcm->subs[i].channel))) {
-                lastChanSub = false;
-                break;
-            }
+    for (i = 0; i < zcm->subInUseEnd; ++i) {
+        if (!zcm->subInUse[i]) continue;
+        /* Note: it would be nice if we didn't have to do a string comp to unsubscribe, but
+                 we need to count the number of channel matches so we know when we can disable
+                 the transport's recvmsg_enable */
+        if (match_idx != i &&
+            strncmp(sub->channel, zcm->subs[i].channel, ZCM_CHANNEL_MAXLEN) == 0) {
+            lastChanSub = false;
+            break;
         }
-
-        if (lastChanSub) rc = zcm_trans_recvmsg_enable(zcm->zt, NULL, false);
-    } else {
-        for (i = 0; i < zcm->subInUseEnd; ++i) {
-            if (!zcm->subInUse[i]) continue;
-            /* Note: it would be nice if we didn't have to do a string comp to unsubscribe, but
-                     we need to count the number of channel matches so we know when we can disable
-                     the transport's recvmsg_enable */
-            if (match_idx != i &&
-                strncmp(sub->channel, zcm->subs[i].channel, ZCM_CHANNEL_MAXLEN) == 0) {
-                lastChanSub = false;
-                break;
-            }
-        }
-
-        if (lastChanSub) rc = zcm_trans_recvmsg_enable(zcm->zt, sub->channel, false);
     }
+
+    if (lastChanSub) rc = zcm_trans_recvmsg_enable(zcm->zt, sub->channel, false);
 
     zcm->subInUse[match_idx] = false;
     while (zcm->subInUseEnd > 0 && !zcm->subInUse[zcm->subInUseEnd - 1]) {
@@ -191,11 +174,11 @@ static void dispatch_message(zcm_nonblocking_t* zcm, zcm_msg_t* msg)
 
         bool shouldDispatch = false;
 
-        size_t subsChanLen = strlen(zcm->subs[i].channel);
-        if (isRegexChannel(zcm->subs[i].channel, subsChanLen)) {
+        if (zcm->subIsRegex[i]) {
             /* This only works because isSupportedRegex() is called on subscribe */
             if (strlen(msg->channel) > 2 &&
-                strncmp(zcm->subs[i].channel, msg->channel, subsChanLen - 2) == 0) {
+                strncmp(zcm->subs[i].channel, msg->channel,
+                        strlen(zcm->subs[i].channel) - 2) == 0) {
                 shouldDispatch = true;
             }
         } else {

--- a/zcm/transport.h
+++ b/zcm/transport.h
@@ -67,19 +67,11 @@
  *      int recvmsg_enable(zcm_trans_t* zt, const char* channel, bool enable)
  *      --------------------------------------------------------------------
  *         This method will enable/disable the receipt of messages on the particular
- *         channel. For 'all channels', the user should pass NULL for the channel.
- *         This method is like a "suggestion", the transport is allowed to "enable"
- *         more channels without concern. This method only sets the "minimum set"
- *         of channels that the user expects to receive. It exists to provide the
- *         transport layer more information for optimization purposes (e.g. the
- *         transport may decide to send each channel over a different endpoint).
- *         If this method is called to disable with channel = NULL, the transport
- *         may only disable receipt of channels that it did not previously receive
- *         an explicit enable command for (i.e. those channels that it would be
- *         receiving had no "receive all" command been given). If a channel is
- *         explicity disabled after channel = NULL has been enabled, the transport
- *         must continue receiving messages on that channel until recv channel = NULL
- *         is disabled.
+ *         channel. This method is like a "suggestion", the transport is allowed to
+ *         "enable" more channels without concern. This method only sets the
+ *         "minimum set" of channels that the user expects to receive. It exists
+ *         to provide the transport layer more information for optimization purposes
+ *         (e.g. the transport may decide to send each channel over a different endpoint).
  *         NOTE: This method should work concurrently and correctly with
  *         recvmsg(). On success, this method should return ZCM_EOK
  *
@@ -122,7 +114,7 @@
  *         Internally, the vtbl field should be set to the appropriate
  *         table of function pointers.
  *
- *      size_t getmtu(zcm_trans_t* zt)
+ *      size_t get_mtu(zcm_trans_t* zt)
  *      --------------------------------------------------------------------
  *         Returns the Maximum Transmission Unit supported by this transport
  *         The transport is allowed to ignore any message above this size
@@ -142,12 +134,11 @@
  *      int recvmsg_enable(zcm_trans_t* zt, const char* channel, bool enable)
  *      --------------------------------------------------------------------
  *         This method will enable/disable the receipt of messages on the particular
- *         channel. For 'all channels', the user should pass NULL for the channel.
- *         This method is like a "suggestion", the transport is allowed to "enable"
- *         more channels without concern. This method only sets the "minimum set"
- *         of channels that the user expects to receive. It exists to provide the
- *         transport layer more information for optimization purposes (e.g. the
- *         transport may decide to send each channel over a different endpoint).
+ *         channel. This method is like a "suggestion", the transport is allowed to
+ *         "enable" more channels without concern. This method only sets the
+ *         "minimum set" of channels that the user expects to receive. It exists to
+ *         provide the transport layer more information for optimization purposes
+ *         (e.g. the transport may decide to send each channel over a different endpoint).
  *         NOTE: This method does NOT have to work concurrently with recvmsg().
  *         On success, this method should return ZCM_EOK
  *

--- a/zcm/transport/transport_zmq_local.cpp
+++ b/zcm/transport/transport_zmq_local.cpp
@@ -299,7 +299,7 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
 
         if (regex) {
             if (enable) {
-                regexChannels.emplace(channel, channel);
+                regexChannels.insert({channel, std::regex(channel)});
             } else {
                 regexChannels.erase(channel);
 

--- a/zcm/transport/transport_zmq_local.cpp
+++ b/zcm/transport/transport_zmq_local.cpp
@@ -291,6 +291,7 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
 
     int recvmsgEnable(const char *channel, bool enable)
     {
+        assert(channel && "channel cannot be null");
         bool regex = isRegexChannel(channel);
         // Mutex used to protect 'subsocks' while allowing
         // recvmsgEnable() and recvmsg() to be called

--- a/zcm/transport/transport_zmq_local.cpp
+++ b/zcm/transport/transport_zmq_local.cpp
@@ -216,15 +216,9 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
             return nullptr;
         }
         subsocks.emplace(channel, make_pair(sock, subExplicit));
-        // RRR Remove this after review and testing
-        ZCM_DEBUG("Creating subsocket for channel %s", channel.c_str());
         return sock;
     }
 
-    // RRR: realizing ... this call gets called once for EVERY new message
-    //      we receive (if you have any regex channels). That's pretty expensive.
-    //      How would you feel about adding like a utime based period for checking?
-    //      Could have that default to like once a second and then be a url param.
     void ipcScanForNewChannels()
     {
         const char *prefix = IPC_NAME_PREFIX;
@@ -340,28 +334,20 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
             } else {
                 auto it = subsocks.find(channel);
                 if (it == subsocks.end()) return ZCM_EINVALID;
-                if (it->second.second) { // This channel has been subscribed to explicitly
-                    // RRR: I'm pretty sure that blocking is handling the reference
-                    //      counting (especially if the channel has both a regex and
-                    //      non-regex subscription), so I think it's ok to just
-                    //      go and delete it right away. Just double checking that
-                    //      that's what you were thinking too.
-                    string address = getAddress(it->first);
-                    int rc = zmq_disconnect(it->second.first, address.c_str());
-                    if (rc == -1) {
-                        ZCM_DEBUG("failed to disconnect subsock: %s", zmq_strerror(errno));
-                        return ZCM_ECONNECT;
-                    }
-
-                    rc = zmq_close(it->second.first);
-                    if (rc == -1) {
-                        ZCM_DEBUG("failed to disconnect subsock: %s", zmq_strerror(errno));
-                        return ZCM_ECONNECT;
-                    }
-                    subsocks.erase(it);
-                    // RRR: remove when done debugging
-                    ZCM_DEBUG("Deleting subsocket for channel %s", it->first.c_str());
+                assert(it->second.second);
+                string address = getAddress(it->first);
+                int rc = zmq_disconnect(it->second.first, address.c_str());
+                if (rc == -1) {
+                    ZCM_DEBUG("failed to disconnect subsock: %s", zmq_strerror(errno));
+                    return ZCM_ECONNECT;
                 }
+
+                rc = zmq_close(it->second.first);
+                if (rc == -1) {
+                    ZCM_DEBUG("failed to disconnect subsock: %s", zmq_strerror(errno));
+                    return ZCM_ECONNECT;
+                }
+                subsocks.erase(it);
             }
             return ZCM_EOK;
         }
@@ -378,6 +364,8 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
             // concurrently
             unique_lock<mutex> lk(mut);
 
+            // XXX Only call this if enough time has ellapse since the last
+            //     time you called it
             if (!regexChannels.empty()) {
                 switch (type) {
                     case IPC: ipcScanForNewChannels();


### PR DESCRIPTION
Pushing regex channel enabling down into the transports. ZMQ local is the only one that meaningfully changes with this. It should be even more efficient since it won't be opening subscription sockets that it doesn't need to open.