### PR TITLE
Log repair

### DIFF
--- a/tools/cpp/log-repair/main.cpp
+++ b/tools/cpp/log-repair/main.cpp
@@ -1,0 +1,91 @@
+#include <iostream>
+
+#include <zcm/zcm-cpp.hpp>
+
+using namespace std;
+
+static atomic_int done {0};
+
+static void sighandler(int signal)
+{
+    done++;
+    if (done == 3) exit(1);
+}
+
+struct Args
+{
+    string infile    = "";
+    string outfile   = "";
+    bool   overwrite = false;
+
+    bool init(int argc, char *argv[])
+    {
+        struct option long_opts[] = {
+            { "help",                no_argument, 0, 'h' },
+            { "output",        required_argument, 0, 'o' },
+            { "overwrite",           no_argument, 0, 'f' },
+            { 0, 0, 0, 0 }
+        };
+
+        int c;
+        while ((c = getopt_long(argc, argv, "ho:f", long_opts, 0)) >= 0) {
+            switch (c) {
+                case 'o':          outfile   = string(optarg); break;
+                case 'f':          overwrite = true;           break;
+                case 'h': default: usage(); return false;
+            };
+        }
+
+        if (optind != argc - 1) {
+            cerr << "Please specify a logfile" << endl;
+            usage();
+            return false;
+        }
+
+        infile = string(argv[optind]);
+
+        if (overwrite) outfile = infile;
+
+        if (outfile.empty()) {
+            cerr << "Must specify output file" << endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    void usage()
+    {
+        cerr << "usage: zcm-log-repair [options] [FILE]" << endl
+             << "" << endl
+             << "    Reads packets from an ZCM log file and re-writes that log file" << endl
+             << "    ensuring that all events are stored in recv_utime order." << endl
+             << "    This is generally only required if the original log was captured" << endl
+             << "    using multiple zcm shards and the user requires a strict ordering" << endl
+             << "    of events in the log." << endl
+             << "" << endl
+             << "Options:" << endl
+             << "" << endl
+             << "  -o, --output=filename  specify output file" << endl
+             << "  -f, --overwrite        write output over the input file" << endl
+             << "  -h, --help             Shows some help text and exits." << endl
+             << endl;
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    LogRepair lr;
+    if (!lr.init(argc, argv)) return 1;
+
+    // Register signal handlers
+    signal(SIGINT, sighandler);
+    signal(SIGQUIT, sighandler);
+    signal(SIGTERM, sighandler);
+
+    int ret = lr.run();
+
+    cout << "zcm-log-repair done" << endl;
+
+    return ret;
+}

--- a/tools/cpp/log-repair/main.cpp
+++ b/tools/cpp/log-repair/main.cpp
@@ -123,6 +123,7 @@ struct LogRepair
         length = ftello(logIn->getFilePtr());
         fseeko(logIn->getFilePtr(), 0, SEEK_SET);
 
+        // somewhat arbitrary, but starting with a high capacity helps speed up the read-in
         timestamps.reserve(1e6);
 
         return true;

--- a/tools/cpp/log-repair/main.cpp
+++ b/tools/cpp/log-repair/main.cpp
@@ -123,23 +123,15 @@ struct LogRepair
         length = ftello(logIn->getFilePtr());
         fseeko(logIn->getFilePtr(), 0, SEEK_SET);
 
-        // RRR (Bendes): This is arbitrary. Why are you doing this?
-        timestamps.reserve(1e6);
-
         return true;
     }
 
     int run()
     {
-        // RRR (Bendes): Doesn't feel responsible to assume we have enough memory
-        //               to build an lookup table of the entire log. Otherwise this
-        //               essentially puts an upper bound on how big a log can be.
-        //               But I see the desire to not to O(n^2) to do it naively
-        //               in passes and to get to something that's better average
-        //               runtime complexity is just more complicated. Maybe just
-        //               drop a comment in here that indicates we know it's a
-        //               problem and are willing to address whenever it becomes
-        //               an issue?
+        // XXX: Note we are reading ALL of the event timestamps into memory, so
+        //      this will use something like 16 * num_events memory. In some use
+        //      cases that won't be ideal, so if people are running into that, we
+        //      can try a different approach.
         cout << "Reading log" << endl;
         progress = 0;
         cout << progress << "%" << flush;

--- a/tools/cpp/log-repair/main.cpp
+++ b/tools/cpp/log-repair/main.cpp
@@ -1,4 +1,13 @@
+#include <algorithm>
+#include <atomic>
 #include <iostream>
+#include <limits>
+#include <utility>
+#include <vector>
+
+#include <getopt.h>
+#include <signal.h>
+#include <unistd.h>
 
 #include <zcm/zcm-cpp.hpp>
 
@@ -16,14 +25,12 @@ struct Args
 {
     string infile    = "";
     string outfile   = "";
-    bool   overwrite = false;
 
     bool init(int argc, char *argv[])
     {
         struct option long_opts[] = {
             { "help",                no_argument, 0, 'h' },
             { "output",        required_argument, 0, 'o' },
-            { "overwrite",           no_argument, 0, 'f' },
             { 0, 0, 0, 0 }
         };
 
@@ -31,7 +38,6 @@ struct Args
         while ((c = getopt_long(argc, argv, "ho:f", long_opts, 0)) >= 0) {
             switch (c) {
                 case 'o':          outfile   = string(optarg); break;
-                case 'f':          overwrite = true;           break;
                 case 'h': default: usage(); return false;
             };
         }
@@ -43,8 +49,6 @@ struct Args
         }
 
         infile = string(argv[optind]);
-
-        if (overwrite) outfile = infile;
 
         if (outfile.empty()) {
             cerr << "Must specify output file" << endl;
@@ -67,9 +71,108 @@ struct Args
              << "Options:" << endl
              << "" << endl
              << "  -o, --output=filename  specify output file" << endl
-             << "  -f, --overwrite        write output over the input file" << endl
              << "  -h, --help             Shows some help text and exits." << endl
              << endl;
+    }
+};
+
+struct LogRepair
+{
+    Args args;
+    zcm::LogFile *logIn  = nullptr;
+    zcm::LogFile *logOut = nullptr;
+
+    const zcm::LogEvent*         event;
+    off_t                        length;
+    off_t                        offset;
+    vector<pair<int64_t, off_t>> timestamps;
+    size_t                       progress;
+
+    LogRepair() { }
+
+    ~LogRepair()
+    {
+        if (logIn)  {
+            if (logIn->good()) logIn->close();
+            delete  logIn;
+        }
+        if (logOut) {
+            if (logOut->good()) logOut->close();
+            delete logOut;
+        }
+    }
+
+    bool init(int argc, char *argv[])
+    {
+        if (!args.init(argc, argv))
+            return false;
+
+        logIn = new zcm::LogFile(args.infile, "r");
+        if (!logIn->good()) {
+            cerr << "Error: Failed to open '" << args.infile << "'" << endl;
+            return false;
+        }
+
+        logOut = new zcm::LogFile(args.outfile, "w");
+        if (!logOut->good()) {
+            cerr << "Error: Failed to create output log" << endl;
+            return false;
+        }
+
+        fseeko(logIn->getFilePtr(), 0, SEEK_END);
+        length = ftello(logIn->getFilePtr());
+        fseeko(logIn->getFilePtr(), 0, SEEK_SET);
+
+        timestamps.reserve(1e6);
+
+        return true;
+    }
+
+    int run()
+    {
+        cout << "Reading log" << endl;
+        progress = 0;
+        cout << progress << "%" << flush;
+        while (true) {
+            if (done) return 1;
+
+            offset = ftello(logIn->getFilePtr());
+            event  = logIn->readNextEvent();
+            if (!event) break;
+
+            timestamps.emplace_back(event->timestamp, offset);
+
+            size_t p = (size_t)((100 * offset) / length);
+            if (p != progress) {
+                progress = p;
+                cout << "\r" << progress << "%" << flush;
+            }
+        }
+        cout << endl << "Read " << timestamps.size() << " events" << endl;
+
+        cout << "Repairing log data" << endl;
+        sort(timestamps.begin(), timestamps.end());
+
+        cout << "Writing new log" << endl;
+        progress = 0;
+        cout << progress << "%" << flush;
+        for (size_t i = 0; i < timestamps.size(); ++i) {
+            if (done) return 1;
+
+            size_t p = (100 * i) / timestamps.size();
+            if (p != progress) {
+                progress = p;
+                cout << "\r" << progress << "%" << flush;
+            }
+
+            logOut->writeEvent(logIn->readEventAtOffset(timestamps[i].second));
+        }
+
+        cout << endl << "Flushing to disk" << endl;
+        logIn->close();
+        logOut->close();
+
+        return 0;
     }
 };
 
@@ -85,7 +188,7 @@ int main(int argc, char* argv[])
 
     int ret = lr.run();
 
-    cout << "zcm-log-repair done" << endl;
+    cout << endl << "zcm-log-repair done" << endl;
 
     return ret;
 }

--- a/tools/cpp/log-repair/main.cpp
+++ b/tools/cpp/log-repair/main.cpp
@@ -123,6 +123,8 @@ struct LogRepair
         length = ftello(logIn->getFilePtr());
         fseeko(logIn->getFilePtr(), 0, SEEK_SET);
 
+        timestamps.reserve(1e6);
+
         return true;
     }
 
@@ -151,6 +153,10 @@ struct LogRepair
 
             timestamps.emplace_back(event->timestamp, offset);
 
+            if (timestamps.size() == timestamps.capacity()) {
+                timestamps.reserve(timestamps.capacity() * 2);
+            }
+
             size_t p = (size_t)((100 * offset) / length);
             if (p != progress) {
                 progress = p;
@@ -158,7 +164,6 @@ struct LogRepair
             }
         }
         cout << endl << "Read " << timestamps.size() << " events" << endl;
-        logIn->close();
 
         if (args.verify) return 0;
 
@@ -214,7 +219,6 @@ struct LogRepair
             cerr << endl << "Error: output log was missing "
                  << timestamps.size() - i << " events" << endl;
         }
-        logOut->close();
 
         return 0;
     }

--- a/tools/cpp/log-repair/wscript
+++ b/tools/cpp/log-repair/wscript
@@ -1,0 +1,7 @@
+#! /usr/bin/env python
+# encoding: utf-8
+
+def build(ctx):
+    ctx.program(target = 'zcm-log-repair',
+                use = ['default', 'zcm'],
+                source = ctx.path.ant_glob('*.cpp'))

--- a/tools/cpp/wscript
+++ b/tools/cpp/wscript
@@ -4,6 +4,7 @@
 def build(ctx):
     ctx.recurse('util');
     ctx.recurse('logplayer');
+    ctx.recurse('log-repair');
     ctx.recurse('repeater');
     ctx.recurse('spy-peek');
 


### PR DESCRIPTION
sort a zcmlog by event timestamp (recv_utime) to repair logs generated by a zcm logger that used multiple shards.