### PR TITLE
Eventlog can be corrupt

### DIFF
--- a/tools/cpp/logplayer/main.cpp
+++ b/tools/cpp/logplayer/main.cpp
@@ -289,6 +289,8 @@ struct LogPlayer
         const zcm::LogEvent* le = zcmIn->readNextEvent();
         uint64_t nowUs = TimeUtil::utime();
 
+        if (!le) return err;
+
         uint64_t firstMsgUtime = (uint64_t) le->timestamp;
         // timestamp when first message is dispatched; will be overwritten in the loop
         uint64_t firstDispatchUtime = nowUs;

--- a/zcm/eventlog.c
+++ b/zcm/eventlog.c
@@ -195,7 +195,7 @@ static zcm_eventlog_event_t *zcm_event_read_helper(zcm_eventlog_t *l, int rewind
             free(le->data);
             free(le);
             le = NULL;
-            return NULL;
+            goto done;
         }
         fseeko (l->f, -4, SEEK_CUR);
     }
@@ -204,6 +204,9 @@ done:
     if (rewindWhenDone) {
         off_t numRead = ftello (l->f) - startOffset;
         fseeko (l->f, -(off_t)(numRead + 4), SEEK_CUR);
+    } else if (le == NULL) {
+        off_t numRead = ftello (l->f) - startOffset;
+        fseeko (l->f, -(off_t)numRead, SEEK_CUR);
     }
     return le;
 }

--- a/zcm/eventlog.c
+++ b/zcm/eventlog.c
@@ -187,6 +187,11 @@ static zcm_eventlog_event_t *zcm_event_read_helper(zcm_eventlog_t *l, int rewind
     }
 
     // Check that there's a valid event or the EOF after this event.
+    // RRR (Bendes): I think this should actually change to be a byte-by-byte
+    //               check for the next magic word. The next magic word could
+    //               restart halfway into the magic word and that would be fine
+    //               but the below code wouldn't allow that.
+    /*
     int32_t next_magic;
     if (0 == fread32(l->f, &next_magic)) {
         if (next_magic != MAGIC) {
@@ -199,6 +204,7 @@ static zcm_eventlog_event_t *zcm_event_read_helper(zcm_eventlog_t *l, int rewind
         }
         fseeko (l->f, -4, SEEK_CUR);
     }
+    */
 
 done:
     if (rewindWhenDone) {


### PR DESCRIPTION
Eventlog reading can now handle corrupted data in the event log. This is specifically useful if you want to cat multiple eventlogs together and then run zcm-log-repair to sort them into a single consistent eventlog.