### PR TITLE
small typo

### DIFF
--- a/gen/disabled/emit_cpp.c
+++ b/gen/disabled/emit_cpp.c
@@ -328,7 +328,7 @@ static void emit_header_start(zcmgen_t *zcmgen, FILE *f, zcm_struct_t *ls)
     emit(2, " *");
     emit(2, " * @param buf The buffer containing the encoded message.");
     emit(2, " * @param offset The byte offset into @p buf where the encoded message starts.");
-    emit(2, " * @param maxlen The maximum number of bytes to reqad while decoding.");
+    emit(2, " * @param maxlen The maximum number of bytes to read while decoding.");
     emit(2, " * @return The number of bytes decoded, or <0 if an error occured.");
     emit(2, " */");
     emit(2, "inline int decode(const void *buf, int offset, int maxlen);");

--- a/gen/emit/EmitCpp.cpp
+++ b/gen/emit/EmitCpp.cpp
@@ -268,7 +268,7 @@ struct Emit : public Emitter
         emit(2, " *");
         emit(2, " * @param buf The buffer containing the encoded message.");
         emit(2, " * @param offset The byte offset into @p buf where the encoded message starts.");
-        emit(2, " * @param maxlen The maximum number of bytes to reqad while decoding.");
+        emit(2, " * @param maxlen The maximum number of bytes to read while decoding.");
         emit(2, " * @return The number of bytes decoded, or <0 if an error occured.");
         emit(2, " */");
         emit(2, "inline int decode(const void* buf, uint32_t offset, uint32_t maxlen);");


### PR DESCRIPTION
Small typo in EmitCpp.cpp for docs on decode function.