### PR TITLE
Update waf arch to debian arch mapping for additional DEST_CPU types

### DIFF
--- a/DEBIAN/wscript
+++ b/DEBIAN/wscript
@@ -7,6 +7,8 @@ waf_arch_dict = {
     "x86"    : 'i386',
     "x86_64" : 'amd64',
     'mips'   : 'mips',
+    'thumb'  : 'armhf',
+    'arm'    : 'armhf',
 #    ''       : 'armel',
 #    ''       : 'armhf',
 #    ''       : 'mips64el',


### PR DESCRIPTION
waf deduces the DEST_CPU type by running
 echo | <compiler> -dM -E -
and extracting information from the default #defines added by the compiler. The validity of this method is questionable since it is possible that multiple of the search terms waf looks for can be found in the output (for example both __thumb__ and __arm__ are often defined at the same time). See
https://waf.io/apidocs/_modules/waflib/Tools/c_config.html for the source code.

I verified that thumb corresponds to armhf by using a docker container built to run on a beagle bone black (a arm/v7l platform): docker run --rm -it --net=host balenalib/beaglebone-black-ubuntu bash

and then comparing the output of
 dkpg --print-architecture
and the above command that waf uses.

However, there is no guarantee this mapping is correct. thumb is an instruction set subtype and armhf is a term mostly made up by debian. It is possible there could be devices that identify as thumb in waf that won't be able to run debian armhf packages. But after some research, that likelihood seems very small.