### PR TITLE
Fix transports that don't handle timeout=0 correctly

### DIFF
--- a/zcm/transport/transport_file.cpp
+++ b/zcm/transport/transport_file.cpp
@@ -123,7 +123,9 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
             //      has occurred. Not sure what to do here since this function
             //      has no way of communicating to the caller that this function
             //      shouldn't be called anymore
-            usleep(timeout);
+            if (timeout > 0) {
+                usleep(timeout);
+            }
             return ZCM_ECONNECT;
         }
 

--- a/zcm/transport/transport_serial.cpp
+++ b/zcm/transport/transport_serial.cpp
@@ -400,7 +400,7 @@ struct ZCM_TRANS_CLASSNAME : public zcm_trans_t
 
     int recvmsg(zcm_msg_t* msg, int timeoutMs)
     {
-        timeoutLeft = timeoutMs > 0 ? timeoutMs * 1e3 : numeric_limits<uint64_t>::max();
+        timeoutLeft = timeoutMs >= 0 ? timeoutMs * 1e3 : numeric_limits<uint64_t>::max();
 
         if (raw) {
             size_t sz = get(rawBuf.get(), rawSize, this);


### PR DESCRIPTION
Most of them handle it correctly. Fixed the ones that don't. May have overlooked a few things. A second pair of eyes would be great.

One weird thing:

`transport_can.cpp` is doing this:
```
uint64_t timeoutUs = timeoutMs >= 0 ? timeoutMs * 1e3 : numeric_limits<uint64_t>::max();
uint64_t timeoutLeft = timeoutUs;
```

And then its' calling the recvmsg function for serial:
```
int ret = zcm_trans_recvmsg(this->gst, msg, timeoutLeft);
```

Looks completely wrong?
