### PR TITLE
Fix zcm-spy showing NoSuchMethod error on java.io.DataInput.  

### DIFF
--- a/tools/java/zcm/logging/Transcoder.java
+++ b/tools/java/zcm/logging/Transcoder.java
@@ -69,7 +69,7 @@ public class Transcoder
                                Long.toHexString(fingerprint));
                 return;
             }
-            Object o = cls.getConstructor(DataInput.class).newInstance(dins);
+            Object o = cls.getConstructor(ZCMDataInputStream.class).newInstance(dins);
 
             ArrayList<Log.Event> events = null;
             events = this.plugin.transcodeMessage(channel, o, utime, ev);

--- a/tools/java/zcm/spy/Spy.java
+++ b/tools/java/zcm/spy/Spy.java
@@ -308,7 +308,7 @@ public class Spy
 
                 cd.nreceived++;
 
-                o = cd.cls.getConstructor(DataInput.class).newInstance(dins);
+                o = cd.cls.getConstructor(ZCMDataInputStream.class).newInstance(dins);
                 cd.last = o;
 
                 if (cd.viewer != null)


### PR DESCRIPTION
Fix zcm-spy showing NoSuchMethod error on java.io.DataInput.  This is a similar fix to #388.

Without this, I could not get zcm-spy to decode any messages.