### PR TITLE
Handle SIGHUP to cause the log to rotate/get a new one manually

### DIFF
--- a/tools/cpp/logger/main.cpp
+++ b/tools/cpp/logger/main.cpp
@@ -208,7 +208,8 @@ struct Args
         }
 
         if (rotate > 0 && auto_increment) {
-            cerr << "ERROR.  --increment and --rotate can't both be used. Note that if you don't want --increment, you must specify a log filename." << endl;
+            cerr << "ERROR.  --increment and --rotate can't both be used." << endl
+                 << "Note that if you don't want --increment, you must specify a log filename." << endl;
             return false;
         }
 
@@ -582,7 +583,7 @@ struct Logger
         }
 
         // Did we get a SIGHUP and the user wants a new logfile?
-        if (got_sighup && (args.auto_increment || (args.rotate > 0))) {
+        if (got_sighup) {
             log->close();
             if (args.rotate > 0)
                 rotate_logfiles();
@@ -703,7 +704,10 @@ int main(int argc, char *argv[])
     signal(SIGINT,  sighandler);
     signal(SIGQUIT, sighandler);
     signal(SIGTERM, sighandler);
-    signal(SIGHUP,  sighup_handler);
+
+    if (logger.args.auto_increment || logger.args.rotate > 0) {
+        signal(SIGHUP,  sighup_handler);
+    }
 
     ZCM_DEBUG("Starting zcms");
     for (auto& z : zcms) z->start();

--- a/tools/cpp/logger/main.cpp
+++ b/tools/cpp/logger/main.cpp
@@ -208,7 +208,7 @@ struct Args
         }
 
         if (rotate > 0 && auto_increment) {
-            cerr << "ERROR.  --increment and --rotate can't both be used" << endl;
+            cerr << "ERROR.  --increment and --rotate can't both be used. Note that if you don't want --increment, you must specify a log filename." << endl;
             return false;
         }
 
@@ -582,7 +582,7 @@ struct Logger
         }
 
         // Did we get a SIGHUP and the user wants a new logfile?
-        if (got_sighup) {
+        if (got_sighup && (args.auto_increment || (args.rotate > 0))) {
             log->close();
             if (args.rotate > 0)
                 rotate_logfiles();

--- a/tools/cpp/logger/main.cpp
+++ b/tools/cpp/logger/main.cpp
@@ -32,6 +32,7 @@ using namespace std;
 #include "platform.hpp"
 
 static atomic_int done {0};
+static atomic_int got_sighup {0};
 
 struct Args
 {
@@ -580,6 +581,19 @@ struct Logger
             }
         }
 
+        // Did we get a SIGHUP and the user wants a new logfile?
+        if (got_sighup) {
+            log->close();
+            if (args.rotate > 0)
+                rotate_logfiles();
+            if (!openLogfile()) exit(1);
+            num_splits++;
+            logsize = 0;
+            last_report_logsize = 0;
+
+            got_sighup = 0;
+        }
+
         if (log->writeEvent(le) != 0) {
             static u64 last_spew_utime = 0;
             string reason = strerror(errno);
@@ -650,6 +664,12 @@ void sighandler(int signal)
     if (done == 3) exit(1);
 }
 
+void sighup_handler(int signal)
+{
+    got_sighup = 1;
+    logger.wakeup();
+}
+
 int main(int argc, char *argv[])
 {
     Platform::setstreambuf();
@@ -683,6 +703,7 @@ int main(int argc, char *argv[])
     signal(SIGINT,  sighandler);
     signal(SIGQUIT, sighandler);
     signal(SIGTERM, sighandler);
+    signal(SIGHUP,  sighup_handler);
 
     ZCM_DEBUG("Starting zcms");
     for (auto& z : zcms) z->start();


### PR DESCRIPTION
The zcm-logger help says that SIGHUP should cause the log to rotate, but that didn't work for me.

I have implemented that functionality here.